### PR TITLE
feat(copilot-setup): add command to scaffold Copilot Setup Steps workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,17 @@
             "dependencies": {
                 "c12": "3.3.3",
                 "citty": "0.1.6",
-                "zod": "^3.24.1"
+                "yaml": "^2.7.0",
+                "zod": "3.24.1"
             },
             "bin": {
                 "lousy-agents": "dist/index.js"
             },
             "devDependencies": {
                 "@biomejs/biome": "2.3.11",
-                "@types/chance": "^1.1.6",
+                "@types/chance": "1.1.6",
                 "@types/node": "24.10.4",
-                "chance": "^1.1.12",
+                "chance": "1.1.12",
                 "tsx": "4.21.0",
                 "typescript": "5.9.3",
                 "vitest": "4.0.16",
@@ -991,7 +992,6 @@
             "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -1468,7 +1468,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1671,7 +1670,6 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -1713,7 +1711,6 @@
             "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -1883,6 +1880,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "c12": "3.3.3",
         "citty": "0.1.6",
+        "yaml": "^2.7.0",
         "zod": "3.24.1"
     },
     "devDependencies": {

--- a/src/commands/copilot-setup.test.ts
+++ b/src/commands/copilot-setup.test.ts
@@ -1,0 +1,363 @@
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Chance from "chance";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { COPILOT_SETUP_WORKFLOW_PATH } from "../lib/workflow-generator.js";
+import { copilotSetupCommand } from "./copilot-setup.js";
+
+const chance = new Chance();
+
+describe("Copilot setup command", () => {
+    let testDir: string;
+
+    beforeEach(async () => {
+        testDir = join(tmpdir(), `test-copilot-setup-${chance.guid()}`);
+        await mkdir(testDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    describe("when detecting environment configuration", () => {
+        it("should create workflow when mise.toml is present", async () => {
+            // Arrange
+            await writeFile(join(testDir, "mise.toml"), '[tools]\nnode = "20"');
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            await expect(access(workflowPath)).resolves.toBeUndefined();
+
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("jdx/mise-action");
+        });
+
+        it("should create workflow with setup-node when .nvmrc is present", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20.11.0");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/setup-node");
+            expect(content).toContain("node-version-file");
+            expect(content).toContain(".nvmrc");
+        });
+
+        it("should create workflow with setup-python when .python-version is present", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".python-version"), "3.12.1");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/setup-python");
+            expect(content).toContain("python-version-file");
+        });
+
+        it("should prioritize mise-action over individual setup actions", async () => {
+            // Arrange
+            await writeFile(join(testDir, "mise.toml"), '[tools]\nnode = "20"');
+            await writeFile(join(testDir, ".nvmrc"), "20.11.0");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("jdx/mise-action");
+            expect(content).not.toContain("actions/setup-node");
+        });
+
+        it("should create minimal workflow when no configuration files exist", async () => {
+            // Arrange - empty directory
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/checkout");
+            expect(content).toContain("Copilot Setup Steps");
+        });
+    });
+
+    describe("when parsing existing workflows", () => {
+        it("should incorporate setup actions from existing workflows", async () => {
+            // Arrange
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+
+            const existingWorkflow = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), existingWorkflow);
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/setup-node");
+        });
+
+        it("should prefer workflow config over version file config", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "18");
+
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+
+            const existingWorkflow = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), existingWorkflow);
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            // Should use node-version from workflow, not node-version-file from .nvmrc
+            expect(content).toContain('node-version: "20"');
+        });
+    });
+
+    describe("when creating new workflow", () => {
+        it("should create .github/workflows directory if it does not exist", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20");
+            const workflowsDir = join(testDir, ".github", "workflows");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            await expect(access(workflowsDir)).resolves.toBeUndefined();
+        });
+
+        it("should include checkout step as first step", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            // Checkout should appear before setup-node
+            const checkoutIndex = content.indexOf("actions/checkout");
+            const setupNodeIndex = content.indexOf("actions/setup-node");
+            expect(checkoutIndex).toBeLessThan(setupNodeIndex);
+        });
+
+        it("should include workflow_dispatch and pull_request triggers", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("workflow_dispatch");
+            expect(content).toContain("pull_request");
+        });
+
+        it("should include required permissions", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("contents: read");
+            expect(content).toContain("id-token: write");
+        });
+    });
+
+    describe("when updating existing workflow", () => {
+        it("should add missing setup steps to existing workflow", async () => {
+            // Arrange
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+
+            const existingWorkflow = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+            await writeFile(
+                join(workflowsDir, "copilot-setup-steps.yml"),
+                existingWorkflow,
+            );
+            await writeFile(join(testDir, ".nvmrc"), "20");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/setup-node");
+        });
+
+        it("should not modify workflow when all steps already present", async () => {
+            // Arrange
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+
+            const existingWorkflow = `name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+`;
+            const workflowPath = join(workflowsDir, "copilot-setup-steps.yml");
+            await writeFile(workflowPath, existingWorkflow);
+            await writeFile(join(testDir, ".nvmrc"), "20");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const content = await readFile(workflowPath, "utf-8");
+            // Content should be unchanged (same structure)
+            expect(content).toContain("actions/setup-node@v4");
+        });
+    });
+
+    describe("when handling multiple version files", () => {
+        it("should create workflow with multiple setup actions", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20");
+            await writeFile(join(testDir, ".python-version"), "3.12");
+
+            // Act
+            await copilotSetupCommand.run({
+                rawArgs: [],
+                args: { _: [] },
+                cmd: copilotSetupCommand,
+                data: { targetDir: testDir },
+            });
+
+            // Assert
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/setup-node");
+            expect(content).toContain("actions/setup-python");
+        });
+    });
+});

--- a/src/commands/copilot-setup.ts
+++ b/src/commands/copilot-setup.ts
@@ -1,0 +1,116 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { CommandContext } from "citty";
+import { defineCommand } from "citty";
+import { consola } from "consola";
+import { detectEnvironment } from "../lib/environment-detector.js";
+import {
+    buildCandidatesFromEnvironment,
+    COPILOT_SETUP_WORKFLOW_PATH,
+    createOrUpdateWorkflow,
+    mergeCandidates,
+} from "../lib/workflow-generator.js";
+import { parseWorkflowsFromRoot } from "../lib/workflow-parser.js";
+
+/**
+ * Dependencies that can be injected for testing
+ */
+interface CopilotSetupDependencies {
+    targetDir?: string;
+    detectEnvironmentFn?: typeof detectEnvironment;
+    parseWorkflowsFn?: typeof parseWorkflowsFromRoot;
+    createOrUpdateWorkflowFn?: typeof createOrUpdateWorkflow;
+}
+
+const copilotSetupArgs = {};
+
+type CopilotSetupArgs = typeof copilotSetupArgs;
+
+export const copilotSetupCommand = defineCommand({
+    meta: {
+        name: "copilot-setup",
+        description:
+            "Create or update the Copilot Setup Steps workflow for GitHub Copilot Coding Agent",
+    },
+    args: copilotSetupArgs,
+    run: async (context: CommandContext<CopilotSetupArgs>) => {
+        // Support dependency injection for testing via context.data
+        const deps = (context.data || {}) as CopilotSetupDependencies;
+        const targetDir = deps.targetDir || process.cwd();
+        const detectEnvironmentFn =
+            deps.detectEnvironmentFn || detectEnvironment;
+        const parseWorkflowsFn =
+            deps.parseWorkflowsFn || parseWorkflowsFromRoot;
+        const createOrUpdateWorkflowFn =
+            deps.createOrUpdateWorkflowFn || createOrUpdateWorkflow;
+
+        consola.start("Detecting environment configuration...");
+
+        // Step 1: Detect environment configuration files
+        const environment = await detectEnvironmentFn(targetDir);
+
+        if (environment.hasMise) {
+            consola.info("Found mise.toml - will use jdx/mise-action");
+        }
+
+        if (environment.versionFiles.length > 0) {
+            const fileNames = environment.versionFiles
+                .map((f) => f.filename)
+                .join(", ");
+            consola.info(`Found version files: ${fileNames}`);
+        }
+
+        // Step 2: Parse existing workflows for setup actions
+        consola.start("Scanning existing workflows...");
+        const workflowCandidates = await parseWorkflowsFn(targetDir);
+
+        if (workflowCandidates.length > 0) {
+            const actionNames = workflowCandidates
+                .map((c) => c.action)
+                .join(", ");
+            consola.info(`Found setup actions in workflows: ${actionNames}`);
+        }
+
+        // Step 3: Build and merge candidates
+        const environmentCandidates =
+            buildCandidatesFromEnvironment(environment);
+        const allCandidates = mergeCandidates(
+            environmentCandidates,
+            workflowCandidates,
+        );
+
+        if (allCandidates.length === 0) {
+            consola.warn(
+                "No environment configuration or setup actions detected. Creating minimal workflow.",
+            );
+        }
+
+        // Step 4: Ensure workflows directory exists
+        const workflowsDir = join(targetDir, ".github", "workflows");
+        await mkdir(workflowsDir, { recursive: true });
+
+        // Step 5: Create or update the workflow
+        const result = await createOrUpdateWorkflowFn(targetDir, allCandidates);
+
+        // Step 6: Report results
+        if (result.created) {
+            consola.success(`Created ${COPILOT_SETUP_WORKFLOW_PATH}`);
+            if (result.addedSteps.length > 0) {
+                consola.info(
+                    `Added setup steps: ${result.addedSteps.join(", ")}`,
+                );
+            } else {
+                consola.info(
+                    "Created minimal workflow with checkout step only",
+                );
+            }
+        } else if (result.updated) {
+            consola.success(`Updated ${COPILOT_SETUP_WORKFLOW_PATH}`);
+            consola.info(`Added setup steps: ${result.addedSteps.join(", ")}`);
+        } else {
+            consola.info(
+                `${COPILOT_SETUP_WORKFLOW_PATH} is already up to date - no changes needed`,
+            );
+        }
+    },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { defineCommand, runMain } from "citty";
+import { copilotSetupCommand } from "./commands/copilot-setup.js";
 import { initCommand } from "./commands/init.js";
 
 const main = defineCommand({
@@ -11,6 +12,7 @@ const main = defineCommand({
     },
     subCommands: {
         init: initCommand,
+        "copilot-setup": copilotSetupCommand,
     },
 });
 

--- a/src/lib/environment-detector.test.ts
+++ b/src/lib/environment-detector.test.ts
@@ -1,0 +1,262 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Chance from "chance";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    detectEnvironment,
+    SUPPORTED_VERSION_FILES,
+} from "./environment-detector.js";
+
+const chance = new Chance();
+
+describe("Environment detector", () => {
+    let testDir: string;
+
+    beforeEach(async () => {
+        testDir = join(tmpdir(), `test-env-${chance.guid()}`);
+        await mkdir(testDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    describe("when detecting mise.toml", () => {
+        it("should return hasMise true when mise.toml exists", async () => {
+            // Arrange
+            const miseTomlPath = join(testDir, "mise.toml");
+            await writeFile(miseTomlPath, "[tools]\nnode = '20'");
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.hasMise).toBe(true);
+        });
+
+        it("should return hasMise false when mise.toml does not exist", async () => {
+            // Arrange - empty directory
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.hasMise).toBe(false);
+        });
+    });
+
+    describe("when detecting .nvmrc", () => {
+        it("should detect .nvmrc file with version content", async () => {
+            // Arrange
+            const nodeVersion = "20.11.0";
+            await writeFile(join(testDir, ".nvmrc"), nodeVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "node",
+                filename: ".nvmrc",
+                version: nodeVersion,
+            });
+        });
+
+        it("should trim whitespace from version content", async () => {
+            // Arrange
+            const nodeVersion = "20.11.0";
+            await writeFile(join(testDir, ".nvmrc"), `  ${nodeVersion}  \n`);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "node",
+                filename: ".nvmrc",
+                version: nodeVersion,
+            });
+        });
+    });
+
+    describe("when detecting .node-version", () => {
+        it("should detect .node-version file with version content", async () => {
+            // Arrange
+            const nodeVersion = "18.19.0";
+            await writeFile(join(testDir, ".node-version"), nodeVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "node",
+                filename: ".node-version",
+                version: nodeVersion,
+            });
+        });
+    });
+
+    describe("when detecting .python-version", () => {
+        it("should detect .python-version file with version content", async () => {
+            // Arrange
+            const pythonVersion = "3.12.1";
+            await writeFile(join(testDir, ".python-version"), pythonVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "python",
+                filename: ".python-version",
+                version: pythonVersion,
+            });
+        });
+    });
+
+    describe("when detecting .java-version", () => {
+        it("should detect .java-version file with version content", async () => {
+            // Arrange
+            const javaVersion = "21";
+            await writeFile(join(testDir, ".java-version"), javaVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "java",
+                filename: ".java-version",
+                version: javaVersion,
+            });
+        });
+    });
+
+    describe("when detecting .ruby-version", () => {
+        it("should detect .ruby-version file with version content", async () => {
+            // Arrange
+            const rubyVersion = "3.3.0";
+            await writeFile(join(testDir, ".ruby-version"), rubyVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "ruby",
+                filename: ".ruby-version",
+                version: rubyVersion,
+            });
+        });
+    });
+
+    describe("when detecting .go-version", () => {
+        it("should detect .go-version file with version content", async () => {
+            // Arrange
+            const goVersion = "1.22.0";
+            await writeFile(join(testDir, ".go-version"), goVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "go",
+                filename: ".go-version",
+                version: goVersion,
+            });
+        });
+    });
+
+    describe("when detecting multiple version files", () => {
+        it("should detect all present version files", async () => {
+            // Arrange
+            const nodeVersion = "20.11.0";
+            const pythonVersion = "3.12.1";
+            await writeFile(join(testDir, ".nvmrc"), nodeVersion);
+            await writeFile(join(testDir, ".python-version"), pythonVersion);
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toHaveLength(2);
+            expect(result.versionFiles).toContainEqual({
+                type: "node",
+                filename: ".nvmrc",
+                version: nodeVersion,
+            });
+            expect(result.versionFiles).toContainEqual({
+                type: "python",
+                filename: ".python-version",
+                version: pythonVersion,
+            });
+        });
+
+        it("should detect both .nvmrc and .node-version if both exist", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "20");
+            await writeFile(join(testDir, ".node-version"), "18");
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            const nodeFiles = result.versionFiles.filter(
+                (f) => f.type === "node",
+            );
+            expect(nodeFiles).toHaveLength(2);
+        });
+    });
+
+    describe("when no configuration files exist", () => {
+        it("should return empty result", async () => {
+            // Arrange - empty directory
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.hasMise).toBe(false);
+            expect(result.versionFiles).toHaveLength(0);
+        });
+    });
+
+    describe("when version file is empty", () => {
+        it("should detect file but version should be undefined", async () => {
+            // Arrange
+            await writeFile(join(testDir, ".nvmrc"), "");
+
+            // Act
+            const result = await detectEnvironment(testDir);
+
+            // Assert
+            expect(result.versionFiles).toContainEqual({
+                type: "node",
+                filename: ".nvmrc",
+                version: undefined,
+            });
+        });
+    });
+
+    describe("SUPPORTED_VERSION_FILES constant", () => {
+        it("should contain all expected version file names", () => {
+            // Arrange
+            const expectedFiles = [
+                ".nvmrc",
+                ".node-version",
+                ".python-version",
+                ".java-version",
+                ".ruby-version",
+                ".go-version",
+            ];
+
+            // Assert
+            for (const file of expectedFiles) {
+                expect(SUPPORTED_VERSION_FILES).toContain(file);
+            }
+        });
+    });
+});

--- a/src/lib/environment-detector.ts
+++ b/src/lib/environment-detector.ts
@@ -1,0 +1,104 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Supported version file types
+ */
+export type VersionFileType = "node" | "python" | "java" | "ruby" | "go";
+
+/**
+ * Represents a detected version file in the repository
+ */
+export interface VersionFile {
+    type: VersionFileType;
+    filename: string;
+    version?: string;
+}
+
+/**
+ * Result of environment detection
+ */
+export interface DetectedEnvironment {
+    hasMise: boolean;
+    versionFiles: VersionFile[];
+}
+
+/**
+ * Mapping of version file names to their types
+ */
+const VERSION_FILE_MAPPINGS: Record<string, VersionFileType> = {
+    ".nvmrc": "node",
+    ".node-version": "node",
+    ".python-version": "python",
+    ".java-version": "java",
+    ".ruby-version": "ruby",
+    ".go-version": "go",
+};
+
+/**
+ * List of all supported version file names
+ */
+export const SUPPORTED_VERSION_FILES = Object.keys(VERSION_FILE_MAPPINGS);
+
+/**
+ * Checks if a file exists by attempting to read it
+ * @param filePath Path to check
+ * @returns True if file exists, false otherwise
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+    try {
+        await readFile(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Reads the content of a file, returning undefined if it doesn't exist
+ * @param filePath Path to read
+ * @returns File content or undefined
+ */
+async function readFileContent(filePath: string): Promise<string | undefined> {
+    try {
+        const content = await readFile(filePath, "utf-8");
+        return content.trim();
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Detects environment configuration files in a repository
+ * @param rootDir The root directory to scan (defaults to current working directory)
+ * @returns DetectedEnvironment with information about found configuration files
+ */
+export async function detectEnvironment(
+    rootDir: string = process.cwd(),
+): Promise<DetectedEnvironment> {
+    // Check for mise.toml
+    const miseTomlPath = join(rootDir, "mise.toml");
+    const hasMise = await fileExists(miseTomlPath);
+
+    // Check for version files
+    const versionFiles: VersionFile[] = [];
+
+    for (const filename of SUPPORTED_VERSION_FILES) {
+        const filePath = join(rootDir, filename);
+        const content = await readFileContent(filePath);
+
+        if (content !== undefined) {
+            const type = VERSION_FILE_MAPPINGS[filename];
+            versionFiles.push({
+                type,
+                filename,
+                version: content || undefined,
+            });
+        }
+    }
+
+    return {
+        hasMise,
+        versionFiles,
+    };
+}

--- a/src/lib/workflow-generator.test.ts
+++ b/src/lib/workflow-generator.test.ts
@@ -1,0 +1,732 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Chance from "chance";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type { DetectedEnvironment } from "./environment-detector.js";
+import {
+    buildCandidatesFromEnvironment,
+    COPILOT_SETUP_WORKFLOW_PATH,
+    createOrUpdateWorkflow,
+    extractExistingActions,
+    generateWorkflowYaml,
+    mergeCandidates,
+    updateWorkflow,
+} from "./workflow-generator.js";
+import type { SetupStepCandidate } from "./workflow-parser.js";
+
+const chance = new Chance();
+
+describe("Workflow generator", () => {
+    describe("buildCandidatesFromEnvironment", () => {
+        it("should create mise-action candidate when mise.toml is present", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: true,
+                versionFiles: [],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "jdx/mise-action",
+                version: "v2",
+                source: "version-file",
+            });
+        });
+
+        it("should create setup-node candidate from .nvmrc when mise is not present", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: false,
+                versionFiles: [
+                    { type: "node", filename: ".nvmrc", version: "20" },
+                ],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "actions/setup-node",
+                version: "v4",
+                config: { "node-version-file": ".nvmrc" },
+                source: "version-file",
+            });
+        });
+
+        it("should create setup-python candidate from .python-version when mise is not present", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: false,
+                versionFiles: [
+                    {
+                        type: "python",
+                        filename: ".python-version",
+                        version: "3.12",
+                    },
+                ],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "actions/setup-python",
+                version: "v5",
+                config: { "python-version-file": ".python-version" },
+                source: "version-file",
+            });
+        });
+
+        it("should skip version file candidates when mise.toml is present", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: true,
+                versionFiles: [
+                    { type: "node", filename: ".nvmrc", version: "20" },
+                ],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            expect(result).toHaveLength(1);
+            expect(result[0].action).toBe("jdx/mise-action");
+        });
+
+        it("should deduplicate node candidates when both .nvmrc and .node-version exist", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: false,
+                versionFiles: [
+                    { type: "node", filename: ".nvmrc", version: "20" },
+                    { type: "node", filename: ".node-version", version: "20" },
+                ],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            const nodeActions = result.filter(
+                (c) => c.action === "actions/setup-node",
+            );
+            expect(nodeActions).toHaveLength(1);
+            // Should use first file encountered (.nvmrc)
+            expect(nodeActions[0].config?.["node-version-file"]).toBe(".nvmrc");
+        });
+
+        it("should create candidates for multiple language version files", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: false,
+                versionFiles: [
+                    { type: "node", filename: ".nvmrc", version: "20" },
+                    {
+                        type: "python",
+                        filename: ".python-version",
+                        version: "3.12",
+                    },
+                    { type: "go", filename: ".go-version", version: "1.22" },
+                ],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            expect(result).toHaveLength(3);
+            expect(result.map((c) => c.action)).toContain("actions/setup-node");
+            expect(result.map((c) => c.action)).toContain(
+                "actions/setup-python",
+            );
+            expect(result.map((c) => c.action)).toContain("actions/setup-go");
+        });
+
+        it("should return empty array when no configuration files present", () => {
+            // Arrange
+            const environment: DetectedEnvironment = {
+                hasMise: false,
+                versionFiles: [],
+            };
+
+            // Act
+            const result = buildCandidatesFromEnvironment(environment);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("mergeCandidates", () => {
+        it("should merge candidates from both sources", () => {
+            // Arrange
+            const envCandidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+            const workflowCandidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-python",
+                    version: "v5",
+                    source: "workflow",
+                },
+            ];
+
+            // Act
+            const result = mergeCandidates(envCandidates, workflowCandidates);
+
+            // Assert
+            expect(result).toHaveLength(2);
+            expect(result.map((c) => c.action)).toContain("actions/setup-node");
+            expect(result.map((c) => c.action)).toContain(
+                "actions/setup-python",
+            );
+        });
+
+        it("should prefer workflow candidate config over environment candidate", () => {
+            // Arrange
+            const envCandidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    config: { "node-version-file": ".nvmrc" },
+                    source: "version-file",
+                },
+            ];
+            const workflowCandidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    config: { "node-version": "20" },
+                    source: "workflow",
+                },
+            ];
+
+            // Act
+            const result = mergeCandidates(envCandidates, workflowCandidates);
+
+            // Assert
+            expect(result).toHaveLength(1);
+            expect(result[0].config).toEqual({ "node-version": "20" });
+            expect(result[0].source).toBe("workflow");
+        });
+
+        it("should handle empty workflow candidates", () => {
+            // Arrange
+            const envCandidates: SetupStepCandidate[] = [
+                {
+                    action: "jdx/mise-action",
+                    version: "v2",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = mergeCandidates(envCandidates, []);
+
+            // Assert
+            expect(result).toEqual(envCandidates);
+        });
+
+        it("should handle empty environment candidates", () => {
+            // Arrange
+            const workflowCandidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "workflow",
+                },
+            ];
+
+            // Act
+            const result = mergeCandidates([], workflowCandidates);
+
+            // Assert
+            expect(result).toEqual(workflowCandidates);
+        });
+    });
+
+    describe("generateWorkflowYaml", () => {
+        it("should generate valid YAML workflow", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    config: { "node-version-file": ".nvmrc" },
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            expect(parsed).toBeDefined();
+            expect(parsed.name).toBe("Copilot Setup Steps");
+        });
+
+        it("should include checkout step as first step", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            const steps = parsed.jobs["copilot-setup-steps"].steps;
+            expect(steps[0].name).toBe("Checkout");
+            expect(steps[0].uses).toBe("actions/checkout@v4");
+        });
+
+        it("should include setup steps after checkout", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            const steps = parsed.jobs["copilot-setup-steps"].steps;
+            expect(steps).toHaveLength(2);
+            expect(steps[1].uses).toBe("actions/setup-node@v4");
+        });
+
+        it("should include action config in with block", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    config: { "node-version-file": ".nvmrc" },
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            const steps = parsed.jobs["copilot-setup-steps"].steps;
+            expect(steps[1].with).toEqual({ "node-version-file": ".nvmrc" });
+        });
+
+        it("should include workflow_dispatch and pull_request triggers", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            expect(parsed.on).toHaveProperty("workflow_dispatch");
+            expect(parsed.on).toHaveProperty("pull_request");
+        });
+
+        it("should include required permissions", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            expect(parsed.permissions.contents).toBe("read");
+            expect(parsed.permissions["id-token"]).toBe("write");
+        });
+
+        it("should use ubuntu-latest runner", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            expect(parsed.jobs["copilot-setup-steps"]["runs-on"]).toBe(
+                "ubuntu-latest",
+            );
+        });
+
+        it("should order mise-action before other setup actions", () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+                {
+                    action: "jdx/mise-action",
+                    version: "v2",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = generateWorkflowYaml(candidates);
+
+            // Assert
+            const parsed = parseYaml(result);
+            const steps = parsed.jobs["copilot-setup-steps"].steps;
+            // Checkout is first, then mise, then setup-node
+            expect(steps[1].uses).toBe("jdx/mise-action@v2");
+            expect(steps[2].uses).toBe("actions/setup-node@v4");
+        });
+    });
+
+    describe("extractExistingActions", () => {
+        it("should extract action names from workflow", () => {
+            // Arrange
+            const workflowContent = `
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+`;
+
+            // Act
+            const result = extractExistingActions(workflowContent);
+
+            // Assert
+            expect(result).toContain("actions/checkout");
+            expect(result).toContain("actions/setup-node");
+        });
+
+        it("should strip version from action names", () => {
+            // Arrange
+            const workflowContent = `
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@60a0d83bf581b792aa7057695fe3246d4474d130
+`;
+
+            // Act
+            const result = extractExistingActions(workflowContent);
+
+            // Assert
+            expect(result).toContain("actions/setup-node");
+            expect(result).not.toContain(
+                "actions/setup-node@60a0d83bf581b792aa7057695fe3246d4474d130",
+            );
+        });
+
+        it("should return empty array for invalid YAML", () => {
+            // Arrange
+            const invalidYaml = "this is not: valid: yaml:";
+
+            // Act
+            const result = extractExistingActions(invalidYaml);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+
+        it("should return empty array for workflow without jobs", () => {
+            // Arrange
+            const workflowContent = `
+name: Empty
+on: [push]
+`;
+
+            // Act
+            const result = extractExistingActions(workflowContent);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("updateWorkflow", () => {
+        it("should append missing steps to existing workflow", () => {
+            // Arrange
+            const existingContent = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    config: { "node-version-file": ".nvmrc" },
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = updateWorkflow(existingContent, candidates);
+
+            // Assert
+            expect(result.updated).toBe(true);
+            expect(result.addedSteps).toContain("actions/setup-node");
+            const parsed = parseYaml(result.content);
+            const steps = parsed.jobs["copilot-setup-steps"].steps;
+            expect(steps).toHaveLength(2);
+        });
+
+        it("should not update when all candidates already present", () => {
+            // Arrange
+            const existingContent = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+`;
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = updateWorkflow(existingContent, candidates);
+
+            // Assert
+            expect(result.updated).toBe(false);
+            expect(result.addedSteps).toEqual([]);
+            expect(result.content).toBe(existingContent);
+        });
+
+        it("should preserve existing workflow content", () => {
+            // Arrange
+            const existingContent = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+  pull_request: {}
+permissions:
+  contents: read
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+`;
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = updateWorkflow(existingContent, candidates);
+
+            // Assert
+            const parsed = parseYaml(result.content);
+            expect(parsed.name).toBe("Copilot Setup Steps");
+            expect(parsed.on).toHaveProperty("workflow_dispatch");
+            expect(parsed.on).toHaveProperty("pull_request");
+            expect(parsed.permissions.contents).toBe("read");
+        });
+
+        it("should only add candidates not already in workflow", () => {
+            // Arrange
+            const existingContent = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+`;
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+                {
+                    action: "actions/setup-python",
+                    version: "v5",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = updateWorkflow(existingContent, candidates);
+
+            // Assert
+            expect(result.updated).toBe(true);
+            expect(result.addedSteps).toEqual(["actions/setup-python"]);
+            expect(result.addedSteps).not.toContain("actions/setup-node");
+        });
+    });
+
+    describe("createOrUpdateWorkflow", () => {
+        let testDir: string;
+
+        beforeEach(async () => {
+            testDir = join(tmpdir(), `test-gen-${chance.guid()}`);
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+        });
+
+        afterEach(async () => {
+            await rm(testDir, { recursive: true, force: true });
+        });
+
+        it("should create new workflow when file does not exist", async () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = await createOrUpdateWorkflow(testDir, candidates);
+
+            // Assert
+            expect(result.created).toBe(true);
+            expect(result.updated).toBe(false);
+            expect(result.addedSteps).toContain("actions/setup-node");
+
+            // Verify file was created
+            const content = await readFile(
+                join(testDir, COPILOT_SETUP_WORKFLOW_PATH),
+                "utf-8",
+            );
+            expect(content).toContain("actions/setup-node");
+        });
+
+        it("should update existing workflow with missing steps", async () => {
+            // Arrange
+            const existingContent = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            await writeFile(workflowPath, existingContent);
+
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = await createOrUpdateWorkflow(testDir, candidates);
+
+            // Assert
+            expect(result.created).toBe(false);
+            expect(result.updated).toBe(true);
+            expect(result.addedSteps).toContain("actions/setup-node");
+
+            // Verify file was updated
+            const content = await readFile(workflowPath, "utf-8");
+            expect(content).toContain("actions/setup-node");
+        });
+
+        it("should not modify file when no changes needed", async () => {
+            // Arrange
+            const existingContent = `
+name: Copilot Setup Steps
+on:
+  workflow_dispatch: {}
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+`;
+            const workflowPath = join(testDir, COPILOT_SETUP_WORKFLOW_PATH);
+            await writeFile(workflowPath, existingContent);
+
+            const candidates: SetupStepCandidate[] = [
+                {
+                    action: "actions/setup-node",
+                    version: "v4",
+                    source: "version-file",
+                },
+            ];
+
+            // Act
+            const result = await createOrUpdateWorkflow(testDir, candidates);
+
+            // Assert
+            expect(result.created).toBe(false);
+            expect(result.updated).toBe(false);
+            expect(result.addedSteps).toEqual([]);
+        });
+
+        it("should create minimal workflow when no candidates provided", async () => {
+            // Arrange
+            const candidates: SetupStepCandidate[] = [];
+
+            // Act
+            const result = await createOrUpdateWorkflow(testDir, candidates);
+
+            // Assert
+            expect(result.created).toBe(true);
+
+            // Verify file contains at least checkout
+            const content = await readFile(
+                join(testDir, COPILOT_SETUP_WORKFLOW_PATH),
+                "utf-8",
+            );
+            expect(content).toContain("actions/checkout");
+        });
+    });
+});

--- a/src/lib/workflow-generator.ts
+++ b/src/lib/workflow-generator.ts
@@ -1,0 +1,406 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import type {
+    DetectedEnvironment,
+    VersionFileType,
+} from "./environment-detector.js";
+import type { SetupStepCandidate } from "./workflow-parser.js";
+
+/**
+ * Represents a step in the generated workflow
+ */
+interface WorkflowStep {
+    name?: string;
+    uses?: string;
+    with?: Record<string, string>;
+    run?: string;
+}
+
+/**
+ * Maps version file types to their corresponding setup actions
+ */
+const VERSION_FILE_TO_ACTION: Record<VersionFileType, string> = {
+    node: "actions/setup-node",
+    python: "actions/setup-python",
+    java: "actions/setup-java",
+    ruby: "actions/setup-ruby",
+    go: "actions/setup-go",
+};
+
+/**
+ * Default versions for setup actions
+ */
+const DEFAULT_ACTION_VERSIONS: Record<string, string> = {
+    "actions/checkout": "v4",
+    "actions/setup-node": "v4",
+    "actions/setup-python": "v5",
+    "actions/setup-java": "v4",
+    "actions/setup-ruby": "v1",
+    "actions/setup-go": "v5",
+    "jdx/mise-action": "v2",
+};
+
+/**
+ * Version file config keys for each action
+ */
+const VERSION_FILE_CONFIG_KEYS: Record<string, string> = {
+    "actions/setup-node": "node-version-file",
+    "actions/setup-python": "python-version-file",
+};
+
+/**
+ * Builds setup step candidates from detected environment
+ * @param environment Detected environment configuration
+ * @returns Array of setup step candidates derived from version files
+ */
+export function buildCandidatesFromEnvironment(
+    environment: DetectedEnvironment,
+): SetupStepCandidate[] {
+    const candidates: SetupStepCandidate[] = [];
+
+    // If mise.toml is present, add mise-action as the primary candidate
+    if (environment.hasMise) {
+        candidates.push({
+            action: "jdx/mise-action",
+            version: DEFAULT_ACTION_VERSIONS["jdx/mise-action"],
+            source: "version-file",
+        });
+    }
+
+    // Add candidates for version files (but skip if mise is present since mise handles everything)
+    if (!environment.hasMise) {
+        // Track which action types we've already added to avoid duplicates
+        const addedActions = new Set<string>();
+
+        for (const versionFile of environment.versionFiles) {
+            const action = VERSION_FILE_TO_ACTION[versionFile.type];
+
+            // Skip if we already have this action
+            if (addedActions.has(action)) {
+                continue;
+            }
+            addedActions.add(action);
+
+            const configKey = VERSION_FILE_CONFIG_KEYS[action];
+            const config = configKey
+                ? { [configKey]: versionFile.filename }
+                : undefined;
+
+            candidates.push({
+                action,
+                version: DEFAULT_ACTION_VERSIONS[action],
+                config,
+                source: "version-file",
+            });
+        }
+    }
+
+    return candidates;
+}
+
+/**
+ * Merges setup step candidates from multiple sources, with workflow sources taking precedence
+ * @param environmentCandidates Candidates from environment detection
+ * @param workflowCandidates Candidates from workflow parsing
+ * @returns Deduplicated array of candidates (workflow config takes precedence)
+ */
+export function mergeCandidates(
+    environmentCandidates: SetupStepCandidate[],
+    workflowCandidates: SetupStepCandidate[],
+): SetupStepCandidate[] {
+    const candidateMap = new Map<string, SetupStepCandidate>();
+
+    // Add environment candidates first
+    for (const candidate of environmentCandidates) {
+        candidateMap.set(candidate.action, candidate);
+    }
+
+    // Workflow candidates override environment candidates (they have more specific config)
+    for (const candidate of workflowCandidates) {
+        candidateMap.set(candidate.action, candidate);
+    }
+
+    return Array.from(candidateMap.values());
+}
+
+/**
+ * Converts a setup step candidate to a workflow step object
+ * @param candidate The setup step candidate
+ * @returns A workflow step object
+ */
+function candidateToStep(candidate: SetupStepCandidate): WorkflowStep {
+    const step: WorkflowStep = {
+        uses: candidate.version
+            ? `${candidate.action}@${candidate.version}`
+            : candidate.action,
+    };
+
+    if (candidate.config && Object.keys(candidate.config).length > 0) {
+        step.with = candidate.config;
+    }
+
+    return step;
+}
+
+/**
+ * Orders candidates in a logical sequence for workflow execution
+ * @param candidates Array of candidates to order
+ * @returns Ordered array (mise first, then alphabetically by action)
+ */
+function orderCandidates(
+    candidates: SetupStepCandidate[],
+): SetupStepCandidate[] {
+    return [...candidates].sort((a, b) => {
+        // mise-action should come first
+        if (a.action === "jdx/mise-action") return -1;
+        if (b.action === "jdx/mise-action") return 1;
+        // Then alphabetically
+        return a.action.localeCompare(b.action);
+    });
+}
+
+/**
+ * Generates a complete Copilot Setup Steps workflow YAML content
+ * @param candidates Array of setup step candidates to include
+ * @returns Generated workflow YAML string
+ */
+export function generateWorkflowYaml(candidates: SetupStepCandidate[]): string {
+    const orderedCandidates = orderCandidates(candidates);
+
+    const steps: WorkflowStep[] = [
+        {
+            name: "Checkout",
+            uses: `actions/checkout@${DEFAULT_ACTION_VERSIONS["actions/checkout"]}`,
+        },
+        ...orderedCandidates.map(candidateToStep),
+    ];
+
+    const workflow = {
+        name: "Copilot Setup Steps",
+        on: {
+            workflow_dispatch: {},
+            pull_request: {},
+        },
+        permissions: {
+            contents: "read",
+            "id-token": "write",
+        },
+        jobs: {
+            "copilot-setup-steps": {
+                "runs-on": "ubuntu-latest",
+                steps,
+            },
+        },
+    };
+
+    return stringifyYaml(workflow, {
+        lineWidth: 0,
+        indent: 2,
+    });
+}
+
+/**
+ * Parses an existing workflow file to extract current steps
+ * @param workflowContent The workflow YAML content
+ * @returns Array of action names currently in the workflow
+ */
+export function extractExistingActions(workflowContent: string): string[] {
+    try {
+        const workflow = parseYaml(workflowContent);
+
+        if (!workflow || typeof workflow !== "object") {
+            return [];
+        }
+
+        const workflowObj = workflow as Record<string, unknown>;
+        const jobs = workflowObj.jobs as Record<string, unknown> | undefined;
+
+        if (!jobs) {
+            return [];
+        }
+
+        const actions: string[] = [];
+
+        for (const jobKey of Object.keys(jobs)) {
+            const job = jobs[jobKey] as Record<string, unknown> | undefined;
+            if (!job) continue;
+
+            const steps = job.steps as unknown[];
+            if (!Array.isArray(steps)) continue;
+
+            for (const step of steps) {
+                if (!step || typeof step !== "object") continue;
+                const stepObj = step as Record<string, unknown>;
+                const uses = stepObj.uses;
+                if (typeof uses === "string") {
+                    // Extract action name without version
+                    const atIndex = uses.indexOf("@");
+                    actions.push(
+                        atIndex === -1 ? uses : uses.substring(0, atIndex),
+                    );
+                }
+            }
+        }
+
+        return actions;
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Result of updating a workflow
+ */
+export interface WorkflowUpdateResult {
+    updated: boolean;
+    content: string;
+    addedSteps: string[];
+}
+
+/**
+ * Updates an existing workflow with missing setup step candidates
+ * @param existingContent The existing workflow YAML content
+ * @param candidates Array of setup step candidates that should be present
+ * @returns Update result with new content and list of added steps
+ */
+export function updateWorkflow(
+    existingContent: string,
+    candidates: SetupStepCandidate[],
+): WorkflowUpdateResult {
+    const existingActions = extractExistingActions(existingContent);
+    const existingActionSet = new Set(existingActions);
+
+    // Filter candidates to only those not already present
+    const missingCandidates = candidates.filter(
+        (c) => !existingActionSet.has(c.action),
+    );
+
+    if (missingCandidates.length === 0) {
+        return {
+            updated: false,
+            content: existingContent,
+            addedSteps: [],
+        };
+    }
+
+    // Parse existing workflow
+    let workflow: Record<string, unknown>;
+    try {
+        workflow = parseYaml(existingContent) as Record<string, unknown>;
+    } catch {
+        // If parsing fails, generate a new workflow
+        return {
+            updated: true,
+            content: generateWorkflowYaml(candidates),
+            addedSteps: candidates.map((c) => c.action),
+        };
+    }
+
+    // Find the copilot-setup-steps job or the first job
+    const jobs = workflow.jobs as Record<string, unknown> | undefined;
+    if (!jobs) {
+        // No jobs, generate fresh workflow
+        return {
+            updated: true,
+            content: generateWorkflowYaml(candidates),
+            addedSteps: candidates.map((c) => c.action),
+        };
+    }
+
+    // Try to find copilot-setup-steps job, otherwise use first job
+    const targetJobKey =
+        "copilot-setup-steps" in jobs
+            ? "copilot-setup-steps"
+            : Object.keys(jobs)[0];
+    const targetJob = jobs[targetJobKey] as Record<string, unknown>;
+
+    if (!targetJob) {
+        return {
+            updated: true,
+            content: generateWorkflowYaml(candidates),
+            addedSteps: candidates.map((c) => c.action),
+        };
+    }
+
+    // Get existing steps
+    let steps = targetJob.steps as WorkflowStep[];
+    if (!Array.isArray(steps)) {
+        steps = [];
+    }
+
+    // Add missing steps at the end (after checkout and existing setup steps)
+    const orderedMissing = orderCandidates(missingCandidates);
+    const newSteps = orderedMissing.map(candidateToStep);
+    targetJob.steps = [...steps, ...newSteps];
+
+    return {
+        updated: true,
+        content: stringifyYaml(workflow, { lineWidth: 0, indent: 2 }),
+        addedSteps: missingCandidates.map((c) => c.action),
+    };
+}
+
+/**
+ * Result of the workflow generation/update operation
+ */
+export interface WorkflowResult {
+    created: boolean;
+    updated: boolean;
+    path: string;
+    addedSteps: string[];
+}
+
+/**
+ * Path to the Copilot Setup Steps workflow file
+ */
+export const COPILOT_SETUP_WORKFLOW_PATH =
+    ".github/workflows/copilot-setup-steps.yml";
+
+/**
+ * Creates or updates the Copilot Setup Steps workflow file
+ * @param rootDir The repository root directory
+ * @param candidates Array of setup step candidates
+ * @returns Result of the operation
+ */
+export async function createOrUpdateWorkflow(
+    rootDir: string,
+    candidates: SetupStepCandidate[],
+): Promise<WorkflowResult> {
+    const workflowPath = join(rootDir, COPILOT_SETUP_WORKFLOW_PATH);
+
+    // Try to read existing workflow
+    let existingContent: string | null = null;
+    try {
+        existingContent = await readFile(workflowPath, "utf-8");
+    } catch {
+        // File doesn't exist
+    }
+
+    if (existingContent === null) {
+        // Create new workflow
+        const content = generateWorkflowYaml(candidates);
+        await writeFile(workflowPath, content, "utf-8");
+
+        return {
+            created: true,
+            updated: false,
+            path: workflowPath,
+            addedSteps: candidates.map((c) => c.action),
+        };
+    }
+
+    // Update existing workflow
+    const updateResult = updateWorkflow(existingContent, candidates);
+
+    if (updateResult.updated) {
+        await writeFile(workflowPath, updateResult.content, "utf-8");
+    }
+
+    return {
+        created: false,
+        updated: updateResult.updated,
+        path: workflowPath,
+        addedSteps: updateResult.addedSteps,
+    };
+}

--- a/src/lib/workflow-parser.test.ts
+++ b/src/lib/workflow-parser.test.ts
@@ -1,0 +1,429 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Chance from "chance";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    isSetupAction,
+    parseActionReference,
+    parseWorkflows,
+    parseWorkflowsFromRoot,
+} from "./workflow-parser.js";
+
+const chance = new Chance();
+
+describe("Workflow parser", () => {
+    describe("parseActionReference", () => {
+        it("should parse action with version tag", () => {
+            // Arrange
+            const uses = "actions/setup-node@v4";
+
+            // Act
+            const result = parseActionReference(uses);
+
+            // Assert
+            expect(result.action).toBe("actions/setup-node");
+            expect(result.version).toBe("v4");
+        });
+
+        it("should parse action with commit SHA", () => {
+            // Arrange
+            const sha = "b4ffde65f46336ab88eb53be808477a3936bae11";
+            const uses = `actions/checkout@${sha}`;
+
+            // Act
+            const result = parseActionReference(uses);
+
+            // Assert
+            expect(result.action).toBe("actions/checkout");
+            expect(result.version).toBe(sha);
+        });
+
+        it("should parse action without version", () => {
+            // Arrange
+            const uses = "actions/setup-node";
+
+            // Act
+            const result = parseActionReference(uses);
+
+            // Assert
+            expect(result.action).toBe("actions/setup-node");
+            expect(result.version).toBeUndefined();
+        });
+    });
+
+    describe("isSetupAction", () => {
+        it("should return true for actions/setup-node", () => {
+            // Assert
+            expect(isSetupAction("actions/setup-node@v4")).toBe(true);
+            expect(isSetupAction("actions/setup-node")).toBe(true);
+        });
+
+        it("should return true for actions/setup-python", () => {
+            // Assert
+            expect(isSetupAction("actions/setup-python@v5")).toBe(true);
+        });
+
+        it("should return true for actions/setup-java", () => {
+            // Assert
+            expect(isSetupAction("actions/setup-java@v4")).toBe(true);
+        });
+
+        it("should return true for actions/setup-go", () => {
+            // Assert
+            expect(isSetupAction("actions/setup-go@v5")).toBe(true);
+        });
+
+        it("should return true for actions/setup-ruby", () => {
+            // Assert
+            expect(isSetupAction("actions/setup-ruby@v1")).toBe(true);
+        });
+
+        it("should return true for jdx/mise-action", () => {
+            // Assert
+            expect(isSetupAction("jdx/mise-action@v2")).toBe(true);
+            expect(isSetupAction("jdx/mise-action")).toBe(true);
+        });
+
+        it("should return false for actions/checkout", () => {
+            // Assert
+            expect(isSetupAction("actions/checkout@v4")).toBe(false);
+        });
+
+        it("should return false for random actions", () => {
+            // Assert
+            expect(isSetupAction("some-org/some-action@v1")).toBe(false);
+        });
+    });
+
+    describe("parseWorkflows", () => {
+        let testDir: string;
+        let workflowsDir: string;
+
+        beforeEach(async () => {
+            testDir = join(tmpdir(), `test-workflows-${chance.guid()}`);
+            workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+        });
+
+        afterEach(async () => {
+            await rm(testDir, { recursive: true, force: true });
+        });
+
+        it("should extract setup-node action from workflow", async () => {
+            // Arrange
+            const workflowContent = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - run: npm test
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "actions/setup-node",
+                version: "v4",
+                config: { "node-version-file": ".nvmrc" },
+                source: "workflow",
+            });
+        });
+
+        it("should extract setup-python action from workflow", async () => {
+            // Arrange
+            const workflowContent = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: '.python-version'
+      - run: pytest
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "actions/setup-python",
+                version: "v5",
+                config: { "python-version-file": ".python-version" },
+                source: "workflow",
+            });
+        });
+
+        it("should extract jdx/mise-action from workflow", async () => {
+            // Arrange
+            const workflowContent = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+      - run: mise run test
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "jdx/mise-action",
+                version: "v2",
+                config: undefined,
+                source: "workflow",
+            });
+        });
+
+        it("should extract setup actions from multiple workflows", async () => {
+            // Arrange
+            const ciWorkflow = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+`;
+            const deployWorkflow = `
+name: Deploy
+on: [push]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), ciWorkflow);
+            await writeFile(join(workflowsDir, "deploy.yaml"), deployWorkflow);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toHaveLength(2);
+            expect(result.map((r) => r.action)).toContain("actions/setup-node");
+            expect(result.map((r) => r.action)).toContain(
+                "actions/setup-python",
+            );
+        });
+
+        it("should deduplicate same action from multiple workflows", async () => {
+            // Arrange
+            const ci1Workflow = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+`;
+            const ci2Workflow = `
+name: CI2
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), ci1Workflow);
+            await writeFile(join(workflowsDir, "ci2.yml"), ci2Workflow);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            const nodeActions = result.filter(
+                (r) => r.action === "actions/setup-node",
+            );
+            expect(nodeActions).toHaveLength(1);
+        });
+
+        it("should return empty array when workflows directory does not exist", async () => {
+            // Arrange
+            const nonExistentDir = join(testDir, "non-existent");
+
+            // Act
+            const result = await parseWorkflows(nonExistentDir);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+
+        it("should return empty array when no setup actions in workflow", async () => {
+            // Arrange
+            const workflowContent = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Hello"
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+
+        it("should skip malformed YAML files", async () => {
+            // Arrange
+            const validWorkflow = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+`;
+            const malformedYaml = `
+name: Bad
+on: [push
+jobs:
+  test:
+    - this: is: not: valid
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), validWorkflow);
+            await writeFile(join(workflowsDir, "bad.yml"), malformedYaml);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toHaveLength(1);
+            expect(result[0].action).toBe("actions/setup-node");
+        });
+
+        it("should handle workflow with no jobs", async () => {
+            // Arrange
+            const workflowContent = `
+name: Empty
+on: [push]
+`;
+            await writeFile(join(workflowsDir, "empty.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+
+        it("should handle job with no steps", async () => {
+            // Arrange
+            const workflowContent = `
+name: NoSteps
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+`;
+            await writeFile(join(workflowsDir, "nosteps.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toEqual([]);
+        });
+
+        it("should extract action with commit SHA version", async () => {
+            // Arrange
+            const sha = "60a0d83bf581b792aa7057695fe3246d4474d130";
+            const workflowContent = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@${sha}
+`;
+            await writeFile(join(workflowsDir, "ci.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflows(workflowsDir);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "actions/setup-node",
+                version: sha,
+                config: undefined,
+                source: "workflow",
+            });
+        });
+    });
+
+    describe("parseWorkflowsFromRoot", () => {
+        let testDir: string;
+
+        beforeEach(async () => {
+            testDir = join(tmpdir(), `test-root-${chance.guid()}`);
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await mkdir(workflowsDir, { recursive: true });
+        });
+
+        afterEach(async () => {
+            await rm(testDir, { recursive: true, force: true });
+        });
+
+        it("should parse workflows from .github/workflows in root directory", async () => {
+            // Arrange
+            const workflowContent = `
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jdx/mise-action@v2
+`;
+            const workflowsDir = join(testDir, ".github", "workflows");
+            await writeFile(join(workflowsDir, "ci.yml"), workflowContent);
+
+            // Act
+            const result = await parseWorkflowsFromRoot(testDir);
+
+            // Assert
+            expect(result).toContainEqual({
+                action: "jdx/mise-action",
+                version: "v2",
+                config: undefined,
+                source: "workflow",
+            });
+        });
+    });
+});

--- a/src/lib/workflow-parser.ts
+++ b/src/lib/workflow-parser.ts
@@ -1,0 +1,191 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Represents a setup step candidate detected from workflows or version files
+ */
+export interface SetupStepCandidate {
+    action: string;
+    version?: string;
+    config?: Record<string, string>;
+    source: "version-file" | "workflow";
+}
+
+/**
+ * Pattern for matching setup actions we care about
+ */
+const SETUP_ACTION_PATTERNS = [
+    /^actions\/setup-node(@.*)?$/,
+    /^actions\/setup-python(@.*)?$/,
+    /^actions\/setup-java(@.*)?$/,
+    /^actions\/setup-go(@.*)?$/,
+    /^actions\/setup-ruby(@.*)?$/,
+    /^jdx\/mise-action(@.*)?$/,
+];
+
+/**
+ * Parses an action reference into action name and version
+ * @param uses The "uses" string from a workflow step (e.g., "actions/setup-node@v4")
+ * @returns Object with action name and optional version
+ */
+export function parseActionReference(uses: string): {
+    action: string;
+    version?: string;
+} {
+    const atIndex = uses.indexOf("@");
+    if (atIndex === -1) {
+        return { action: uses };
+    }
+    return {
+        action: uses.substring(0, atIndex),
+        version: uses.substring(atIndex + 1),
+    };
+}
+
+/**
+ * Checks if an action reference matches a setup action pattern
+ * @param uses The "uses" string from a workflow step
+ * @returns True if this is a setup action we care about
+ */
+export function isSetupAction(uses: string): boolean {
+    return SETUP_ACTION_PATTERNS.some((pattern) => pattern.test(uses));
+}
+
+/**
+ * Extracts setup step candidates from a workflow YAML structure
+ * @param workflow Parsed workflow YAML object
+ * @returns Array of setup step candidates found in the workflow
+ */
+function extractSetupStepsFromWorkflow(
+    workflow: unknown,
+): SetupStepCandidate[] {
+    const candidates: SetupStepCandidate[] = [];
+
+    if (!workflow || typeof workflow !== "object") {
+        return candidates;
+    }
+
+    const workflowObj = workflow as Record<string, unknown>;
+    const jobs = workflowObj.jobs;
+
+    if (!jobs || typeof jobs !== "object") {
+        return candidates;
+    }
+
+    const jobsObj = jobs as Record<string, unknown>;
+
+    for (const jobKey of Object.keys(jobsObj)) {
+        const job = jobsObj[jobKey];
+        if (!job || typeof job !== "object") {
+            continue;
+        }
+
+        const jobObj = job as Record<string, unknown>;
+        const steps = jobObj.steps;
+
+        if (!Array.isArray(steps)) {
+            continue;
+        }
+
+        for (const step of steps) {
+            if (!step || typeof step !== "object") {
+                continue;
+            }
+
+            const stepObj = step as Record<string, unknown>;
+            const uses = stepObj.uses;
+
+            if (typeof uses !== "string") {
+                continue;
+            }
+
+            if (!isSetupAction(uses)) {
+                continue;
+            }
+
+            const { action, version } = parseActionReference(uses);
+            const withConfig = stepObj.with as
+                | Record<string, unknown>
+                | undefined;
+
+            const config: Record<string, string> | undefined = withConfig
+                ? Object.fromEntries(
+                      Object.entries(withConfig)
+                          .filter(([, v]) => typeof v === "string")
+                          .map(([k, v]) => [k, v as string]),
+                  )
+                : undefined;
+
+            candidates.push({
+                action,
+                version,
+                config:
+                    config && Object.keys(config).length > 0
+                        ? config
+                        : undefined,
+                source: "workflow",
+            });
+        }
+    }
+
+    return candidates;
+}
+
+/**
+ * Parses workflow files in a directory to extract setup action candidates
+ * @param workflowsDir The path to the .github/workflows directory
+ * @returns Array of unique setup step candidates found across all workflows
+ */
+export async function parseWorkflows(
+    workflowsDir: string,
+): Promise<SetupStepCandidate[]> {
+    const candidates: SetupStepCandidate[] = [];
+
+    // Try to read the workflows directory
+    let files: string[];
+    try {
+        files = await readdir(workflowsDir);
+    } catch {
+        // Directory doesn't exist or can't be read
+        return candidates;
+    }
+
+    // Filter for YAML files
+    const yamlFiles = files.filter(
+        (f) => f.endsWith(".yml") || f.endsWith(".yaml"),
+    );
+
+    // Parse each workflow file
+    for (const filename of yamlFiles) {
+        const filePath = join(workflowsDir, filename);
+        try {
+            const content = await readFile(filePath, "utf-8");
+            const workflow = parseYaml(content);
+            const workflowCandidates = extractSetupStepsFromWorkflow(workflow);
+            candidates.push(...workflowCandidates);
+        } catch {}
+    }
+
+    // Deduplicate by action name (prefer first occurrence which has full config)
+    const seenActions = new Set<string>();
+    return candidates.filter((candidate) => {
+        if (seenActions.has(candidate.action)) {
+            return false;
+        }
+        seenActions.add(candidate.action);
+        return true;
+    });
+}
+
+/**
+ * Parses workflows from a repository root directory
+ * @param rootDir The repository root directory
+ * @returns Array of unique setup step candidates found in .github/workflows
+ */
+export async function parseWorkflowsFromRoot(
+    rootDir: string = process.cwd(),
+): Promise<SetupStepCandidate[]> {
+    const workflowsDir = join(rootDir, ".github", "workflows");
+    return parseWorkflows(workflowsDir);
+}


### PR DESCRIPTION
This adds a new `copilot-setup` command that automatically detects environment configuration and creates/updates the Copilot Setup Steps workflow for GitHub Copilot Coding Agent.

Features:
- Detects mise.toml and version files (.nvmrc, .node-version, etc.)
- Parses existing workflows for setup actions to preserve configuration
- Generates workflow with checkout and detected setup steps
- Updates existing copilot-setup-steps.yml with missing steps
- Prioritizes mise-action over individual setup actions when mise.toml present

New modules:
- environment-detector: Scans for version management configuration
- workflow-parser: Extracts setup actions from existing workflows
- workflow-generator: Builds candidates and generates/updates YAML

Closes task implementation from spec for Copilot Setup Steps Workflow Scaffold.