### PR TITLE
fix(test): eliminate flaky mtimeMs comparison against wall clock

### DIFF
--- a/.lousy-agents/lessons/no-walltime-vs-filesystem-timestamp.md
+++ b/.lousy-agents/lessons/no-walltime-vs-filesystem-timestamp.md
@@ -1,0 +1,56 @@
+---
+slug: no-walltime-vs-filesystem-timestamp
+title: Never assert filesystem timestamps against Date.now()
+type: invariant
+created: 2026-05-29
+revised: 2026-05-29
+provenance: []
+triggers:
+  paths:
+    - "**/*.test.ts"
+    - "**/*.spec.ts"
+  tags:
+    - "test"
+    - "spec"
+  patterns:
+    - "Date.now"
+    - "mtimeMs"
+    - "toBeGreaterThanOrEqual"
+---
+
+A real filesystem/OS timestamp (e.g. `stat().mtimeMs`) and `Date.now()` are **independent clock reads** — the kernel stamps a file's mtime from its own clock, while `Date.now()` reads V8's wall clock. They are not guaranteed monotonic relative to each other. Asserting `mtime >= before` (where `before = Date.now()` captured around a write) is therefore inherently flaky: on CI the recorded mtime can land a few milliseconds *behind* the wall-clock reading, intermittently failing the assertion.
+
+Fudge factors (`before - 1`) and `Math.floor(mtimeMs)` do **not** fix this — they only narrow the window. The flake recurs. This was learned the hard way in `packages/core/src/gateways/file-system-utils.test.ts`, where the `statWithinRoot` mtime test failed twice on `main` after two separate symptom patches.
+
+## When It Applies
+
+- Any test that compares a value sourced from the filesystem or OS (file mtime/ctime/atime, log timestamps) against `Date.now()` / `new Date()`.
+- Any assertion of the form `expect(fsTimestamp).toBeGreaterThanOrEqual(wallClockTimestamp)`.
+
+## Correct Application
+
+There are two sound approaches, chosen by layer:
+
+**(a) Unit layer — inject the clock/`stat`.** When the code under test takes time or `stat` as a dependency, provide a fake with fixed values. `packages/agent-shell/src/gateways/log-query.ts` accepts an injected `stat`, and its unit test (`packages/agent-shell/tests/log/query.test.ts`) supplies `{ mtimeMs: 1000 }`, `{ mtimeMs: 2000 }` — fully deterministic, no real clock involved.
+
+**(b) Real-fs layer — compare against a same-source reference.** When the gateway deliberately wraps the real filesystem (so mocking it would defeat the test), do not compare to `Date.now()` at all. Read a reference from the **same** source and compare to that:
+
+```typescript
+// ✅ Good — same-source reference, compared to the nearest millisecond
+await writeFile(join(testDir, "file.txt"), chance.word());
+const reference = await stat(join(testDir, "file.txt"));
+const result = await statWithinRoot(testDir, "file.txt");
+expect(result.mtimeMs).toBeCloseTo(reference.mtimeMs, 0);
+
+// ❌ Bad — cross-clock comparison, flaky regardless of fudge/floor
+const before = Date.now();
+await writeFile(join(testDir, "file.txt"), chance.word());
+const result = await statWithinRoot(testDir, "file.txt");
+expect(Math.floor(result.mtimeMs)).toBeGreaterThanOrEqual(before - 1);
+```
+
+## Edge Cases
+
+- Even a same-source reference is not safe with exact equality: Node derives `mtimeMs` as a float from the nanosecond timestamp, and the value is **not bit-stable across stat calls** on the same file (observed jitter ~0.0003 ms, e.g. `...962.1733` vs `...962.1736`). Compare to the nearest millisecond — `toBeCloseTo(ref, 0)` or `Math.floor` equality — not `.toBe()`. The stable integer source is `mtimeNs` (BigInt, via `stat(path, { bigint: true })`) if you need exactness.
+- A fake clock (`vi.useFakeTimers` / `vi.setSystemTime`) does **not** rescue approach (b): it controls only JS time, never the kernel's file mtime. Freezing `Date.now()` makes the divergence worse, not better.
+- If a test genuinely needs an "is recent" sanity check, assert membership in a generous window (e.g. within minutes) rather than a tight `>=` against a clock read — but prefer the same-source reference whenever possible.

--- a/packages/core/src/gateways/file-system-utils.test.ts
+++ b/packages/core/src/gateways/file-system-utils.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Chance from "chance";
@@ -276,15 +276,16 @@ describe("statWithinRoot", () => {
         });
 
         it("should return a numeric mtimeMs representing the modification time", async () => {
-            const before = Date.now();
             await writeFile(join(testDir, "file.txt"), chance.word());
+            const reference = await stat(join(testDir, "file.txt"));
 
             const result = await statWithinRoot(testDir, "file.txt");
 
             expect(typeof result.mtimeMs).toBe("number");
-            expect(Math.floor(result.mtimeMs)).toBeGreaterThanOrEqual(
-                before - 1,
-            );
+            // Same file, same source — but Node derives mtimeMs as a float
+            // from the nanosecond timestamp and it is not bit-stable across
+            // stat calls, so compare to the nearest millisecond.
+            expect(result.mtimeMs).toBeCloseTo(reference.mtimeMs, 0);
         });
     });
 


### PR DESCRIPTION
## Summary

- Fixes a flaky test in `packages/core/src/gateways/file-system-utils.test.ts` that caused two `main` CI failures ([#25977788594](https://github.com/zpratt/lousy-agents/actions/runs/25977788594/job/76360959290), [#26655919611](https://github.com/zpratt/lousy-agents/actions/runs/26655919611/job/78565893548))
- Root cause: the test compared a filesystem `mtimeMs` against `Date.now()` — these are independent, non-monotonic clocks; on CI the kernel's recorded mtime landed ~2ms behind the V8 wall-clock read, and the existing `before - 1` / `Math.floor` patches only masked the symptom
- Secondary finding: even two `stat()` calls on the same file return non-bit-stable `mtimeMs` floats (~0.0003ms jitter), so exact equality is also unsound
- Fix: compare against a same-source reference `stat()` using `toBeCloseTo(ref, 0)` (nearest millisecond) — removes the cross-clock comparison entirely
- Adds invariant lesson `no-walltime-vs-filesystem-timestamp.md` so this pattern isn't reintroduced

## Test plan

- [x] Rewritten test passes (18/18 in `file-system-utils.test.ts`)
- [x] Verified deterministic over 60 consecutive runs (zero failures; old version flaked ~1-in-5 locally)
- [x] `mise run lint` exits 0 (includes lesson schema validation)
- [x] Full unit suite exits 0 — 95 files, 1706 tests
- [ ] `mise run ci` (smoke-test requires Docker/testcontainers, not available locally — will run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)