### PR TITLE
docs(instructions): dedupe Claude Code and Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ eval "$(mise activate zsh)"
 
 # Core commands
 mise run test            # Run tests (vitest)
-mise run lint            # Run ALL linting tools in parallel (Biome, actionlint, yamllint, markdownlint, shellcheck, issue-form schemas)
+mise run lint            # Run ALL linting tools in parallel (Biome, actionlint, yamllint, markdownlint, shellcheck, semgrep, dependency-cruiser, issue-form schemas)
 mise run format-check    # Biome only — code formatting + static analysis
 mise run format-fix      # Auto-fix Biome lint/format issues
 npm run build            # Production build

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ npm run build            # Production build
 
 # Workspace-scoped commands
 npm run build --workspace=packages/cli     # Build CLI only
-npm test --workspace=packages/cli          # Test a specific package
+npm test -- packages/cli/src               # Test files in a specific package path
 
 # File-scoped (faster feedback)
 npx biome check path/to/file.ts

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ npx biome check path/to/file.ts
 npm test path/to/file.test.ts
 
 # Validation suite (run before commits)
-mise run ci              # Runs: lint -> test -> test-integration -> smoke-test (smoke-test builds then exercises the CLI)
+mise run ci              # Runs: lint -> test -> test-integration -> smoke-test (test-integration and smoke-test both depend on build)
 
 # Other
 npm audit                # Security check

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,13 +8,16 @@ applyTo: "**"
 
 ## Shared Instruction Architecture
 
-This repo provides instructions for both GitHub Copilot and Claude Code. The detailed domain instructions in `.github/instructions/` are the shared source-of-truth referenced by both systems.
+This repo serves instructions to both GitHub Copilot and Claude Code from a single set of canonical files, organized so each topic lives in exactly one place:
 
-`CLAUDE.md` uses `@path/to/file` syntax (e.g., `@.github/instructions/test.instructions.md`) to import those shared files. This is Claude Code's native file reference mechanism — **not** a broken markdown link. Do not suggest converting `@path/to/file` references in `CLAUDE.md` to markdown links.
+- **This file (`.github/copilot-instructions.md`)** is the canonical home for **repo-wide general guidance** (commands, TDD workflow, tech stack, project structure, code style, dependencies, boundaries, task tracking). Copilot code review always loads it; Claude Code imports it from the root `CLAUDE.md`.
+- **`.github/instructions/*.instructions.md`** are the canonical home for **scoped domain rules** (testing, software architecture, specs, pipelines). Each has an `applyTo` glob. Copilot code review auto-applies them to matching changed files; Claude Code imports them from nested `CLAUDE.md` files placed in the matching directories. The general sections in this file deliberately summarize (not duplicate) those rules and link to them.
+
+`CLAUDE.md` files use `@path/to/file` syntax (e.g., `@.github/copilot-instructions.md`) to import these shared files. This is Claude Code's native file reference mechanism — **not** a broken markdown link. Do not suggest converting `@path/to/file` references in any `CLAUDE.md` to markdown links. Copilot does **not** follow `@import` or markdown links, so anything Copilot review must see is kept physically in this file or in `.github/instructions/*`.
 
 ## Commands
 
-Mise manages all tools and Node versions. If you haven't activated mise in your shell, run `mise activate` once or prefix commands with `mise exec --`. During development, use file-scoped commands for faster feedback, and run the full validation suite (`mise run ci && npm run build`) before commits.
+Mise manages all tools and Node versions. If you haven't activated mise in your shell, run `mise activate` once or prefix commands with `mise exec --`. During development, use file-scoped commands for faster feedback, and run the full validation suite (`mise run ci`) before commits.
 
 ```bash
 # One-time shell setup (or add to ~/.zshrc)
@@ -22,21 +25,21 @@ eval "$(mise activate zsh)"
 
 # Core commands
 mise run test            # Run tests (vitest)
+mise run lint            # Run ALL linting tools in parallel (Biome, actionlint, yamllint, markdownlint, shellcheck, issue-form schemas)
+mise run format-check    # Biome only — code formatting + static analysis
+mise run format-fix      # Auto-fix Biome lint/format issues
 npm run build            # Production build
-mise run format-check    # Lint check
-mise run format-fix      # Auto-fix lint/format
+
+# Workspace-scoped commands
+npm run build --workspace=packages/cli     # Build CLI only
+npm test --workspace=packages/cli          # Test a specific package
 
 # File-scoped (faster feedback)
 npx biome check path/to/file.ts
 npm test path/to/file.test.ts
 
 # Validation suite (run before commits)
-mise run ci && npm run build
-
-# Linting tasks
-mise run actionlint      # Validate GitHub Actions (actionlint)
-mise run yamllint        # Validate YAML (yamllint)
-mise run lint            # Run all linting tools in parallel
+mise run ci              # Runs: lint -> test -> test-integration -> smoke-test (smoke-test builds then exercises the CLI)
 
 # Other
 npm audit                # Security check
@@ -57,9 +60,10 @@ Follow this exact sequence for ALL code changes. Work in small increments — ma
 4. **Implement minimal code**: Write just enough to pass
 5. **Verify pass**: Run `mise run test` — confirm pass
 6. **Refactor**: Clean up, remove duplication, keep tests green
-7. **Validate**: `mise run ci && npm run build`
+7. **Verify refactor**: Run `mise run test && mise run lint` — confirm tests still green and all linting passes
+8. **Validate**: `mise run ci` — runs `lint -> test -> test-integration -> smoke-test`
 
-Task is NOT complete until all validation passes.
+Task is NOT complete until `mise run ci` exits 0.
 
 ## Tech Stack
 
@@ -142,114 +146,9 @@ async function doStuff(x) {
 
 ## Testing Standards
 
-Tests are executable documentation. Use Arrange-Act-Assert pattern. Mock HTTP with MSW. Generate test fixtures with Chance.js.
+TDD is required (see the workflow above). Tests are executable documentation: describe behavior, not implementation. Use Vitest (never Jest), mock HTTP with MSW (never mock `fetch` directly), and generate fixtures with Chance.js. Follow Arrange-Act-Assert, name `describe`/`it` blocks as specifications, extract test data to constants (never duplicate values across arrange/act/assert), and cover happy paths, unhappy paths, and edge cases. Tests must be deterministic and isolated. Never modify a test to pass without fixing the root cause.
 
-```typescript
-import Chance from 'chance';
-import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
-import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
-import { fetchUserById } from './user-service';
-
-const chance = new Chance();
-const server = setupServer();
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-
-// ✅ Good - describes behavior, reads like documentation, uses generated fixtures
-describe('User retrieval', () => {
-  describe('given a valid user ID', () => {
-    it('returns the user details from the API', async () => {
-      // Arrange
-      const userId = chance.guid();
-      const expectedUser = { id: userId, name: chance.name() };
-      server.use(
-        http.get(`/api/users/${userId}`, () => {
-          return HttpResponse.json(expectedUser);
-        })
-      );
-
-      // Act
-      const result = await fetchUserById(userId);
-
-      // Assert
-      expect(result).toEqual(expectedUser);
-    });
-  });
-
-  describe('given an empty user ID', () => {
-    it('rejects with a validation error', async () => {
-      // Arrange - no server setup needed, validation happens before fetch
-
-      // Act & Assert
-      await expect(fetchUserById('')).rejects.toThrow('User ID required');
-    });
-  });
-
-  describe('given a non-existent user ID', () => {
-    it('rejects with an error containing the status code', async () => {
-      // Arrange
-      const userId = chance.guid();
-      server.use(
-        http.get(`/api/users/${userId}`, () => {
-          return new HttpResponse(null, { status: 404 });
-        })
-      );
-
-      // Act & Assert
-      await expect(fetchUserById(userId)).rejects.toThrow(
-        'Failed to fetch user: 404'
-      );
-    });
-  });
-
-  describe('given an invalid response shape', () => {
-    it('rejects with a validation error', async () => {
-      // Arrange
-      const userId = chance.guid();
-      server.use(
-        http.get(`/api/users/${userId}`, () => {
-          return HttpResponse.json({ invalid: 'data' });
-        })
-      );
-
-      // Act & Assert
-      await expect(fetchUserById(userId)).rejects.toThrow();
-    });
-  });
-});
-
-// ❌ Bad - implementation-focused, hardcoded values, duplicated test data
-describe('fetchUserById', () => {
-  it('works', async () => {
-    const user = { id: '123', name: 'Alice' };
-    server.use(
-      http.get('/api/users/123', () => HttpResponse.json(user))
-    );
-    const result = await fetchUserById('123'); // duplicated '123' across arrange/act/assert
-    expect(result).toEqual(user);
-  });
-});
-```
-
-**Rules:**
-- Tests are executable documentation — describe behavior, not implementation
-- Name `describe` blocks for features/scenarios, not function names
-- Name `it` blocks as specifications that read as complete sentences
-- Use nested `describe` blocks for "given/when" context
-- Use Chance.js to generate test fixtures — avoid hardcoded test data
-- Extract test data to constants — never duplicate values across arrange/act/assert
-- Use Vitest (never Jest)
-- Mock HTTP with MSW (never mock fetch directly)
-- Follow Arrange-Act-Assert pattern
-- Tests must be deterministic — same result every run
-- Reset handlers between tests for isolation
-- Avoid conditional logic in tests unless absolutely necessary
-- Ensure all code paths have corresponding tests
-- Test happy paths, unhappy paths, and edge cases
-- Never modify tests to pass without understanding root cause
+**Full conventions — including worked examples, the complete rule list, and dependency-injection-for-testing patterns — live in the canonical [`.github/instructions/test.instructions.md`](./instructions/test.instructions.md)**, which Copilot code review auto-applies to changed test files (`packages/**/*.{test,spec}.{ts,tsx}`).
 
 ## Dependencies
 
@@ -263,11 +162,9 @@ describe('fetchUserById', () => {
 
 ## GitHub Actions
 
-- Validation must be automated via GitHub Actions and runnable locally the same way
-- Validate all workflows using actionlint
-- Validate all YAML files using yamllint
-- Pin all 3rd party Actions to specific version or commit SHA
-- Keep all 3rd party Actions updated to latest version
+Validation must be automated via GitHub Actions and runnable locally the same way. Every workflow needs test and lint jobs; validate workflows with actionlint and YAML with yamllint (`mise run lint` runs both). Pin all third-party Actions to an exact commit SHA with a version comment and keep them current.
+
+**Full workflow conventions — SHA-pinning format, required jobs, runner requirements — live in the canonical [`.github/instructions/pipeline.instructions.md`](./instructions/pipeline.instructions.md)**, which Copilot code review auto-applies to changed workflow files (`.github/workflows/*.{yml,yaml}`).
 
 ## Boundaries
 

--- a/.github/specs/CLAUDE.md
+++ b/.github/specs/CLAUDE.md
@@ -1,0 +1,7 @@
+# Spec Instructions
+
+These rules apply when working on spec files (`*.spec.md`) in this directory. They are the canonical spec-development instructions that Copilot code review auto-applies via `applyTo`, loaded here for Claude Code so they are in context whenever you draft or edit a spec.
+
+## Spec Development
+
+@../instructions/spec.instructions.md

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,9 @@
+# Workflow Instructions
+
+These rules apply when modifying GitHub Actions workflows in this directory. They are the canonical pipeline instructions that Copilot code review auto-applies via `applyTo`, loaded here for Claude Code so they are in context whenever you edit a workflow.
+
+After modifying any workflow, run `mise run lint`.
+
+## Pipeline Conventions
+
+@../instructions/pipeline.instructions.md

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -2,8 +2,6 @@
 
 These rules apply when modifying GitHub Actions workflows in this directory. They are the canonical pipeline instructions that Copilot code review auto-applies via `applyTo`, loaded here for Claude Code so they are in context whenever you edit a workflow.
 
-After modifying any workflow, run `mise run lint`.
-
 ## Pipeline Conventions
 
 @../instructions/pipeline.instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Reach for these project skills when the work matches:
 
 ## Memory
 
-A persistent file-based memory lives at `~/.claude/projects/-Users-zpratt-Developer-lousy-agents/memory/` with an index at `MEMORY.md`. Record durable, non-obvious facts there (user preferences, confirmed feedback, ongoing project constraints) — not things already captured by the repo, git history, or these instruction files.
+A persistent file-based memory lives under `~/.claude/projects/<repo-id>/memory/` with an index at `MEMORY.md`. Record durable, non-obvious facts there (user preferences, confirmed feedback, ongoing project constraints) — not things already captured by the repo, git history, or these instruction files.
 
 ## Review & subagent workflow
 
@@ -59,7 +59,7 @@ This project uses [mise](https://mise.jdx.dev/) for runtime management.
 
 ### Detected Runtimes
 
-- **node**: .nvmrc (v24.14.0)
+- **node**: .nvmrc (v24.15.0)
 
 ### Package Managers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,212 +4,54 @@ Lousy Agents is a scaffolding tool that helps software engineers improve their w
 
 See @.github/context/project.context.md for full project context.
 
----
+## General engineering guidance (shared with Copilot)
 
-## Commands
+All repo-wide engineering guidance — Commands, the TDD workflow, Tech Stack, Project Structure, Code Style, Dependencies, Task Tracking, and Boundaries — is maintained in one canonical place and imported here:
 
-Mise manages all tools and Node versions. Use file-scoped commands for faster feedback during development.
+@.github/copilot-instructions.md
 
-```bash
-# Core commands
-mise run test            # Run tests (vitest)
-mise run lint            # Run ALL linting tools in parallel (Biome, actionlint, yamllint, markdownlint, shellcheck, issue-form schemas)
-mise run format-check    # Biome only — code formatting + static analysis
-mise run format-fix      # Auto-fix Biome lint/format issues
-npm run build            # Production build
+Do not duplicate that content below. To change a general rule, edit `.github/copilot-instructions.md` (it is the single source, and the file Copilot code review always loads).
 
-# Workspace-scoped commands
-npm run build --workspace=packages/cli     # Build CLI only
-npm run build --workspace=packages/mcp     # Build MCP server only
-npm test --workspace=packages/cli          # Test a specific package
+## Instruction map
 
-# File-scoped (faster feedback)
-npx biome check path/to/file.ts
-npm test path/to/file.test.ts
+Guidance is organized so each topic lives in exactly one canonical file:
 
-# Validation suite (run before commits)
-mise run ci              # Runs: lint -> test -> smoke-test (smoke-test builds then exercises the CLI)
+- **Repo-wide general rules** → `.github/copilot-instructions.md` (imported above).
+- **Scoped domain rules** → `.github/instructions/*.instructions.md`. Each has an `applyTo` glob. Copilot code review auto-applies them to matching changed files; Claude Code loads them from the **nested `CLAUDE.md`** placed in the matching directory:
+  - `packages/CLAUDE.md` → software-architecture + test conventions
+  - `.github/workflows/CLAUDE.md` → pipeline conventions
+  - `.github/specs/CLAUDE.md` → spec-development conventions
 
-# Other
-npm audit                # Security check
-npm install              # Install deps
-```
-
-In GitHub Actions, `jdx/mise-action` automatically activates mise and makes all tools available in PATH.
+Keeping the deep domain rules in nested files (rather than importing all of them here) mirrors Copilot's `applyTo` scoping and keeps this root file lean: architecture/test/spec/pipeline guidance loads only when you are actually working in that area.
 
 ---
 
-## Workflow: TDD Required
+## Task Tracking (Claude-specific)
 
-Follow this sequence for ALL code changes. Work in small increments — one change at a time, validate before proceeding.
+Beads (`bd`) is the single source of truth for all task tracking (see Boundaries in the imported guidance). For Claude Code specifically:
 
-1. **Research**: Search codebase for existing patterns. Use Context7 MCP tools for library/API documentation.
-2. **Write failing test**: Create test describing desired behavior
-3. **Verify failure**: Run `mise run test` — confirm clear failure message
-4. **Implement minimal code**: Write just enough to pass
-5. **Verify pass**: Run `mise run test` — confirm pass
-6. **Refactor**: Clean up, remove duplication
-7. **Verify refactor**: Run `mise run test && mise run lint` — confirm tests still green and all linting passes
-8. **Validate**: Run `mise run ci` — runs `mise run lint`, `mise run test`, and `mise run smoke-test` (which builds then exercises the CLI)
+**Never** use Claude Code's native task tools (`TaskCreate`, `TaskList`, `TaskUpdate`, `TaskGet`, etc.) for project tasks — they are session-scoped and invisible to other agents and to Copilot. Use `bd create` / `bd show <id>` / `bd close <id>` / `bd list` / `bd query` instead. If `bd` is unavailable, stop and inform the user — do not fall back to native tools or ad-hoc lists.
 
-Task is NOT complete until step 8 validation passes. Never skip `mise run lint` — it runs Biome, actionlint, yamllint, markdownlint, shellcheck, and issue-form schema validation.
+## Skills
 
----
+Reach for these project skills when the work matches:
 
-## Tech Stack
+- **`feature-to-plan`** — turn a feature request, idea, or backlog issue into a structured EARS-format spec.
+- **`plan-to-graph`** — break a spec/master plan into a Beads (`bd`) dependency graph of epics and tasks.
+- **`mutation-hunter`** — find test-coverage gaps by mutating production TypeScript and seeing which mutations survive.
+- **`rugged-evil-tester`** — generate adversarial / security / boundary / injection tests for TypeScript.
+- **`triaging-pr-reviews`** — triage and classify PR review comments (especially automated Copilot review) before acting on them.
 
-- **Framework**: CLI using c12 for configuration, citty for terminal interactions
-  - Prefer libraries from the [UnJS ecosystem](https://unjs.io/)
-- **Language**: TypeScript (strict mode)
-- **Validation**: Zod for runtime validation of external data
-- **Testing**: Vitest (never Jest), MSW for HTTP mocking, Chance.js for test fixtures
-- **Linting**: Biome (never ESLint/Prettier separately)
-- **Logging**: Consola with JSON format and child loggers
-- **HTTP**: fetch API only
-- **Architecture**: Clean Architecture principles
+## Memory
+
+A persistent file-based memory lives at `~/.claude/projects/-Users-zpratt-Developer-lousy-agents/memory/` with an index at `MEMORY.md`. Record durable, non-obvious facts there (user preferences, confirmed feedback, ongoing project constraints) — not things already captured by the repo, git history, or these instruction files.
+
+## Review & subagent workflow
+
+- Use **Explore/Plan subagents** for research and design when scope is uncertain or spans multiple areas; prefer your own tools for focused, well-understood changes.
+- Before finishing code work, run a review pass: use `/security-review` or `/code-review` on the diff. This mirrors the `@Reviewer` security-and-architecture handoff described in the imported guidance — when handling user input (CLI args, file content, env vars), validate with Zod and check for path traversal, command injection, and prototype pollution.
 
 ---
-
-## Project Structure
-
-This is a monorepo using npm workspaces. The root `package.json` defines five
-workspace packages under `packages/`:
-
-```
-.github/             GitHub Actions workflows, Copilot instructions, specs
-packages/
-  core/              @lousy-agents/core — shared entities, use cases, gateways
-  cli/               @lousy-agents/cli — CLI entry point and commands
-    src/
-      entities/      Layer 1: Business domain entities
-      use-cases/     Layer 2: Application business rules
-      gateways/      Layer 3: External system adapters
-      commands/      Layer 3: CLI command handlers
-      lib/           Layer 3: Configuration and utilities
-      index.ts       Layer 4: Composition root (CLI)
-    api/             REST API scaffold templates
-    ui/              Webapp scaffold templates
-  mcp/               @lousy-agents/mcp — MCP server
-    src/
-      tools/         MCP tool handlers
-      server.ts      MCP server setup
-  action/            @lousy-agents/action — GitHub Action
-  agent-shell/       @lousy-agents/agent-shell — npm script flight recorder
-```
-
-Tests are co-located with source files within each package (no separate `tests/` root directory).
-
----
-
-## Code Style
-
-- Always use TypeScript type hints
-- Use descriptive names for variables, functions, and modules
-- Functions must be small with single responsibility
-- Favor immutability and pure functions
-- Avoid temporal coupling
-- Keep cyclomatic complexity low
-- Remove all unused imports and variables
-- Validate external data at runtime with Zod — never use type assertions (`as Type`) on API responses
-- Always check `response.ok` when using fetch
-- Run `mise run test && mise run lint` after every change
-
----
-
-## Testing Conventions
-
-When writing or modifying test files (`*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`):
-
-**Mandatory**: Run `mise run test` after modifying or creating tests.
-
-See @.github/instructions/test.instructions.md for detailed conventions including test file structure, Chance.js usage, MSW mocking, dependency injection patterns, and all test design rules.
-
----
-
-## Software Architecture
-
-When working with source code in `src/`, follow Clean Architecture. Dependencies point inward only: Entities -> Use Cases -> Adapters -> Infrastructure.
-
-See @.github/instructions/software-architecture.instructions.md for layer definitions, directory structure, dependency injection patterns (constructor injection and factory functions), import rules, and anti-patterns.
-
----
-
-## Spec Development
-
-When working with spec files (`*.spec.md`):
-
-See @.github/instructions/spec.instructions.md for the full spec development workflow including EARS requirement syntax, user story format, value assessment, persona development, task design guidelines, Mermaid diagram requirements, and coding agent anti-patterns.
-
----
-
-## CI/CD Pipelines
-
-When modifying GitHub workflows (`.github/workflows/*.yml`, `.github/workflows/*.yaml`):
-
-**Mandatory**: Run `mise run lint` after modifying workflows.
-
-See @.github/instructions/pipeline.instructions.md for workflow structure requirements, action SHA pinning format, and runner requirements.
-
----
-
-## Dependencies
-
-- Pin ALL dependencies to exact versions (no `^` or `~`)
-- Search npm for latest stable version before adding
-- Use explicit version numbers: `npm install <package>@<exact-version>`
-- Run `npm audit` after any dependency change
-- Ensure `package-lock.json` is updated correctly
-
----
-
-## Task Tracking
-
-Beads (`bd`) is the single source of truth for all task tracking in this project. AI agents must not use native task management as a substitute.
-
-**Always do:**
-- Use `bd create` to create new issues/tasks
-- Use `bd show <id>` to read task context before starting work
-- Use `bd close <id>` when a task is complete
-- Use `bd list` or `bd query` to discover open work
-
-**Never do:**
-- Use Claude Code's native task tools (`TaskCreate`, `TaskList`, `TaskUpdate`, etc.) for project tasks — these are session-scoped and invisible to other agents
-- Invent ad-hoc session-scoped task lists — all tasks must live in Beads
-- Mark tasks complete in any system other than Beads
-
-**If `bd` is unavailable:** do not fall back to native tools or ad-hoc lists — stop and inform the user that Beads must be installed before proceeding with task tracking.
-
----
-
-## Boundaries
-
-**Definition of Done — a task is complete only when all three conditions are met:**
-1. `mise run ci` exits 0 (runs `mise run lint` → `mise run test` → `mise run smoke-test`)
-2. All acceptance criteria from the task or issue are satisfied
-3. No warnings or errors were ignored or suppressed to reach exit 0
-
-Do not signal task completion, propose a commit, or open a PR until these conditions are met.
-
-**Always do:**
-- Write tests before implementation (TDD)
-- Run `mise run test && mise run lint` after every change
-- Use existing patterns from codebase
-- Work in small increments
-
-**Ask first:**
-- Adding new dependencies
-- Changing project structure
-- Modifying GitHub Actions workflows
-
-**Never do:**
-- Skip the TDD workflow
-- Claim a task is complete without `mise run ci` exiting 0
-- Store secrets in code (use environment variables)
-- Use Jest (use Vitest)
-- Mock fetch directly (use MSW)
-- Modify tests to pass without fixing root cause
-- Add dependencies without explicit version numbers
-- Use type assertions (`as Type`) on external/API data
 
 ## Environment Setup
 

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,0 +1,11 @@
+# Package Source Instructions
+
+These rules apply when working in any workspace package under `packages/`. They are the canonical domain instructions that Copilot code review auto-applies via `applyTo`, loaded here for Claude Code so they are in context whenever you edit package source or tests.
+
+## Software Architecture
+
+@../.github/instructions/software-architecture.instructions.md
+
+## Testing Conventions
+
+@../.github/instructions/test.instructions.md


### PR DESCRIPTION
## Why

The repo maintained the same general engineering guidance in **two** top-level files (`CLAUDE.md` and `.github/copilot-instructions.md`) plus full inline copies of testing/pipeline rules that duplicated the canonical `.github/instructions/*` files. These had already **drifted** — most visibly, `mise run ci` was described three different ways across the files (none fully accurate; it actually runs `lint → test → test-integration → smoke-test`).

This PR establishes **one canonical source per topic** with no drift, while honoring the hard constraint that **Copilot PR review only loads `.github/copilot-instructions.md` + `.github/instructions/*` and does not follow `@import` or markdown links** — so everything Copilot needs stays physically in those files.

## What changed

**`.github/copilot-instructions.md`** — now the single source for repo-wide general guidance:
- Slimmed the **Testing Standards** section (removed the ~90-line example + duplicated rules) to a short policy + pointer to the canonical `test.instructions.md`.
- Slimmed **GitHub Actions** to a short policy + pointer to `pipeline.instructions.md`.
- Reconciled the **`mise run ci`** drift and the TDD/command list against `mise.toml`.
- Rewrote **Shared Instruction Architecture** to document the new model.

**`CLAUDE.md`** (root) — now thin:
- Imports `@.github/copilot-instructions.md` instead of restating Commands / TDD / Tech Stack / Structure / Code Style / Dependencies / Boundaries.
- Adds Claude-only sections: skills pointers, memory note, subagent/review workflow, Beads native-task-tool prohibition, and an instruction map.

**New nested `CLAUDE.md` files** (`packages/`, `.github/workflows/`, `.github/specs/`):
- Import the scoped instruction files, mirroring Copilot's `applyTo` scoping for Claude while keeping the root file lean. These are invisible to Copilot review, so the constraint is preserved.

The four `.github/instructions/*.instructions.md` files and their `applyTo` frontmatter are **unchanged** — they remain the canonical deep-domain source for both systems.

## Verification

- ✅ `mise run lint` → 0 errors (Biome, actionlint, yamllint, markdownlint, shellcheck, issue-form schemas, semgrep)
- ✅ unit `test` → 40 passed, 3 skipped
- ✅ All six `@import` targets resolve
- ⚠️ `test-integration` fails only because Docker/testcontainers is unavailable in the dev sandbox — pre-existing and unrelated to these markdown-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)