### PR TITLE
chore(agents): mise-managed Node toolchain for Claude Code cloud sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,5 +7,18 @@
         "claude-md-management@claude-plugins-official": true,
         "claude-code-setup@claude-plugins-official": true
     },
-    "SessionStart": ["mise install", "npm ci"]
+    "SessionStart": ["mise install", "npm ci"],
+    "hooks": {
+        "SessionStart": [
+            {
+                "matcher": "startup|resume",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/mise-path.sh"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,3 +238,48 @@ npm ci
 ```
 
 *Install Node.js dependencies with package-lock.json*
+
+On cloud sessions (`CLAUDE_CODE_REMOTE=true`), `scripts/mise-path.sh` also runs
+and prepends `/mise/shims` to `PATH` so the agent shell resolves the correct
+Node version without sourcing a login profile.
+
+### Cloud Environment Config (apply once in the Claude Code web UI)
+
+These settings must be applied manually in the cloud environment editor. They
+are recorded here so the setup is reproducible and reviewable.
+
+**Environment variables**
+
+```
+MISE_DATA_DIR=/mise
+MISE_CONFIG_DIR=/mise
+MISE_CACHE_DIR=/mise/cache
+```
+
+**Setup script** (runs as root at container build time; output is snapshot-cached)
+
+```bash
+#!/bin/bash
+set -e
+export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache
+
+# Install mise via npm (npm registry is allowlisted on the default Trusted network)
+npm install -g @jdxcode/mise
+
+# Enable idiomatic version file support for Node so mise reads .nvmrc
+mise settings add idiomatic_version_file_enable_tools node
+
+# Install Node (version from .nvmrc) and all tools from mise.toml into /mise
+mise trust -a
+mise install
+```
+
+**Verification** (run in a cloud session after config is applied)
+
+```bash
+mise --version                                        # mise is installed
+mise settings get idiomatic_version_file_enable_tools # should include: node
+node -v                                               # matches .nvmrc
+which node                                            # resolves under /mise/shims
+mise ls                                               # node Source: .nvmrc
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,8 +263,8 @@ MISE_CACHE_DIR=/mise/cache
 set -e
 export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache
 
-# Install mise via npm (npm registry is allowlisted on the default Trusted network)
-npm install -g @jdxcode/mise@2026.4.20
+# Install mise — pin to the version that satisfies min_version in mise.toml
+curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise MISE_VERSION=v2026.5.16 sh
 
 # Enable idiomatic version file support for Node so mise reads .nvmrc
 mise settings add idiomatic_version_file_enable_tools node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ set -e
 export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache
 
 # Install mise via npm (npm registry is allowlisted on the default Trusted network)
-npm install -g @jdxcode/mise
+npm install -g @jdxcode/mise@2026.4.20
 
 # Enable idiomatic version file support for Node so mise reads .nvmrc
 mise settings add idiomatic_version_file_enable_tools node

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ hide = true
 
 [tasks.shellcheck]
 description = "Running shellcheck against shell scripts"
-run = "find . -not -path '*/node_modules/*' -name '*.sh' -exec shellcheck {} +"
+run = "find . -path '*/node_modules' -prune -o -name '*.sh' -exec shellcheck {} +"
 hide = true
 
 [tasks.semgrep]

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ hide = true
 
 [tasks.shellcheck]
 description = "Running shellcheck against shell scripts"
-run = "files=$(find . -not -path '*/node_modules/*' -name '*.sh' 2>/dev/null); [ -n \"$files\" ] && echo \"$files\" | xargs shellcheck || echo 'No shell scripts found, skipping shellcheck'"
+run = "find . -not -path '*/node_modules/*' -name '*.sh' -print0 2>/dev/null | xargs -r -0 shellcheck"
 hide = true
 
 [tasks.semgrep]

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ hide = true
 
 [tasks.shellcheck]
 description = "Running shellcheck against shell scripts"
-run = "find . -not -path '*/node_modules/*' -name '*.sh' -print0 2>/dev/null | xargs -r -0 shellcheck"
+run = "find . -not -path '*/node_modules/*' -name '*.sh' -exec shellcheck {} +"
 hide = true
 
 [tasks.semgrep]

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,7 @@ hide = true
 
 [tasks.shellcheck]
 description = "Running shellcheck against shell scripts"
-run = "[ -n \"$(ls -A *.sh 2>/dev/null)\" ] && shellcheck *.sh || echo 'No shell scripts found, skipping shellcheck'"
+run = "files=$(find . -not -path '*/node_modules/*' -name '*.sh' 2>/dev/null); [ -n \"$files\" ] && echo \"$files\" | xargs shellcheck || echo 'No shell scripts found, skipping shellcheck'"
 hide = true
 
 [tasks.semgrep]

--- a/scripts/mise-path.sh
+++ b/scripts/mise-path.sh
@@ -2,4 +2,7 @@
 # Cloud-only: prepend mise shims to PATH so the agent's non-interactive shell resolves
 # the correct Node version. Skipped on local sessions where nvm manages Node instead.
 [ "$CLAUDE_CODE_REMOTE" = "true" ] || exit 0
-echo "PATH=/mise/shims:$PATH" >> "$CLAUDE_ENV_FILE"
+case ":${PATH}:" in
+  *":/mise/shims:"*) ;;
+  *) echo "PATH=/mise/shims:$PATH" >> "$CLAUDE_ENV_FILE" ;;
+esac

--- a/scripts/mise-path.sh
+++ b/scripts/mise-path.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Cloud-only: prepend mise shims to PATH so the agent's non-interactive shell resolves
+# the correct Node version. Skipped on local sessions where nvm manages Node instead.
+[ "$CLAUDE_CODE_REMOTE" = "true" ] || exit 0
+echo "PATH=/mise/shims:$PATH" >> "$CLAUDE_ENV_FILE"

--- a/scripts/mise-path.sh
+++ b/scripts/mise-path.sh
@@ -3,6 +3,6 @@
 # the correct Node version. Skipped on local sessions where nvm manages Node instead.
 [ "$CLAUDE_CODE_REMOTE" = "true" ] || exit 0
 case ":${PATH}:" in
-  *":/mise/shims:"*) ;;
+  ":/mise/shims:"*) ;;
   *) echo "PATH=/mise/shims:$PATH" >> "$CLAUDE_ENV_FILE" ;;
 esac


### PR DESCRIPTION
## Summary

- Adds `scripts/mise-path.sh`: a cloud-only SessionStart hook that writes `/mise/shims` to `PATH` via `$CLAUDE_ENV_FILE`, so the agent's non-interactive shell picks up the Node version pinned in `.nvmrc` without touching the local nvm workflow
- Registers the script in `.claude/settings.json` under the `hooks.SessionStart` matcher, merged alongside the existing `mise install` / `npm ci` hooks
- Documents the required cloud environment config (env vars + setup script) in `CLAUDE.md` so the setup is reproducible and reviewable by humans

## What stays the same

- `.nvmrc` remains the single source of truth for the Node version — no version duplicated into any mise config
- Local sessions are completely untouched: the `CLAUDE_CODE_REMOTE=true` guard in the hook script is a no-op outside cloud

## Cloud environment config (applied manually in the web UI — not in this PR)

```
MISE_DATA_DIR=/mise
MISE_CONFIG_DIR=/mise
MISE_CACHE_DIR=/mise/cache
```

Setup script (runs as root, output snapshot-cached):
```bash
#!/bin/bash
set -e
export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache
curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise MISE_VERSION=v2026.5.16 sh
mise settings add idiomatic_version_file_enable_tools node
mise trust -a
mise install
```

## Test plan

- [ ] After applying cloud env config, open a cloud session and verify `which node` resolves under `/mise/shims`
- [ ] Verify `node -v` matches `.nvmrc` (`v24.16.0`)
- [ ] Verify `mise ls` shows node sourced from `.nvmrc`
- [ ] Verify a local session is unaffected (no `/mise/shims` in PATH, nvm still owns Node)

https://claude.ai/code/session_016CNxmhCSBvy6wiERMHqx5z

---
_Generated by [Claude Code](https://claude.ai/code/session_016CNxmhCSBvy6wiERMHqx5z)_