### PR TITLE
feat(doctor): implement @lousy-agents/agentic-doctor package

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -105,6 +105,8 @@ depends = ["build"]
 run = [
   "./packages/cli/dist/index.js --help",
   "./packages/cli/dist/index.js init --help",
+  "./packages/cli/dist/index.js doctor --help",
+  "node ./packages/cli/dist/index.js doctor --summary --format json --ci",
 ]
 
 [tasks.ci] # only dependencies to be run

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "packages/cli",
                 "packages/mcp",
                 "packages/action",
-                "packages/agent-shell"
+                "packages/agent-shell",
+                "packages/doctor"
             ],
             "devDependencies": {
                 "@biomejs/biome": "2.5.1",
@@ -111,9 +112,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -131,9 +129,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -151,9 +146,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -171,9 +163,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -831,6 +820,10 @@
         },
         "node_modules/@lousy-agents/agent-shell": {
             "resolved": "packages/agent-shell",
+            "link": true
+        },
+        "node_modules/@lousy-agents/agentic-doctor": {
+            "resolved": "packages/doctor",
             "link": true
         },
         "node_modules/@lousy-agents/cli": {
@@ -1519,9 +1512,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1536,9 +1526,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1553,9 +1540,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1570,9 +1554,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1587,9 +1568,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1604,9 +1582,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7496,6 +7471,23 @@
             "devDependencies": {
                 "@types/mdast": "4.0.4",
                 "@types/picomatch": "4.0.3"
+            }
+        },
+        "packages/doctor": {
+            "name": "@lousy-agents/agentic-doctor",
+            "version": "0.1.0",
+            "license": "BSD-2-Clause-Patent",
+            "dependencies": {
+                "citty": "0.2.2",
+                "consola": "3.4.2",
+                "yaml": "2.9.0",
+                "zod": "4.4.3"
+            },
+            "bin": {
+                "agentic-doctor": "dist/cli/index.js"
+            },
+            "devDependencies": {
+                "@lousy-agents/core": "*"
             }
         },
         "packages/lint": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "packages/cli",
         "packages/mcp",
         "packages/action",
-        "packages/agent-shell"
+        "packages/agent-shell",
+        "packages/doctor"
     ],
     "repository": {
         "type": "git",
@@ -32,7 +33,7 @@
     ],
     "scripts": {
         "dev": "tsx packages/cli/src/index.ts",
-        "build": "npm run build --workspace=packages/lint --workspace=packages/cli --workspace=packages/mcp --workspace=packages/agent-shell --workspace=packages/action",
+        "build": "npm run build --workspace=packages/lint --workspace=packages/doctor --workspace=packages/cli --workspace=packages/mcp --workspace=packages/agent-shell --workspace=packages/action",
         "start": "node packages/cli/dist/index.js",
         "test": "vitest run",
         "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
         "zod": "4.4.3"
     },
     "devDependencies": {
+        "@lousy-agents/agentic-doctor": "*",
         "@lousy-agents/core": "*",
         "@lousy-agents/lint": "*"
     }

--- a/packages/cli/src/commands/doctor.integration.test.ts
+++ b/packages/cli/src/commands/doctor.integration.test.ts
@@ -1,0 +1,147 @@
+import { execFile } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliBin = resolve(__dirname, "..", "..", "dist", "index.js");
+const fixturesDir = resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "doctor",
+    "tests",
+    "fixtures",
+);
+
+function fixture(name: string): string {
+    return resolve(fixturesDir, name);
+}
+
+interface ExecResult {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+}
+
+async function runDoctor(args: string[], cwd: string): Promise<ExecResult> {
+    try {
+        const result = await execFileAsync(
+            process.execPath,
+            [cliBin, "doctor", ...args],
+            {
+                cwd,
+                // biome-ignore lint/style/useNamingConvention: env var
+                env: { ...process.env, NO_COLOR: "1" },
+            },
+        );
+        return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+    } catch (err: unknown) {
+        const e = err as { code?: number; stdout?: string; stderr?: string };
+        return {
+            exitCode: e.code ?? 1,
+            stdout: e.stdout ?? "",
+            stderr: e.stderr ?? "",
+        };
+    }
+}
+
+describe("doctor command", () => {
+    describe("when invoked with --help", () => {
+        it("should display usage and exit 0", async () => {
+            // Arrange
+            const cwd = process.cwd();
+
+            // Act
+            const { exitCode, stdout } = await runDoctor(["--help"], cwd);
+
+            // Assert
+            expect(exitCode).toBe(0);
+            expect(stdout).toMatch(/doctor/i);
+            expect(stdout).toMatch(/--summary/);
+            expect(stdout).toMatch(/--format/);
+        });
+    });
+
+    describe("when run with --summary --format json on an empty repo", () => {
+        it("should output a valid JSON summary and exit 0", async () => {
+            // Arrange
+            const cwd = fixture("empty-repo");
+
+            // Act
+            const { exitCode, stdout } = await runDoctor(
+                ["--summary", "--format", "json"],
+                cwd,
+            );
+
+            // Assert
+            expect(exitCode).toBe(0);
+            const report = JSON.parse(stdout) as Record<string, unknown>;
+            expect(report).toHaveProperty("archetype", "none");
+            expect(report).toHaveProperty("totalRecords", 0);
+            expect(report).not.toHaveProperty("findings");
+        });
+    });
+
+    describe("when run with --format json on an empty repo", () => {
+        it("should output valid JSON with no findings and exit 0", async () => {
+            // Arrange
+            const cwd = fixture("empty-repo");
+
+            // Act
+            const { exitCode, stdout } = await runDoctor(
+                ["--format", "json"],
+                cwd,
+            );
+
+            // Assert
+            expect(exitCode).toBe(0);
+            const report = JSON.parse(stdout) as {
+                archetype: string;
+                findings: unknown[];
+            };
+            expect(report.archetype).toBe("none");
+            expect(report.findings).toHaveLength(0);
+        });
+    });
+
+    describe("when run with --format json on the integration-scenario fixture", () => {
+        it("should produce a critical missing-copilot-instructions finding and exit 1", async () => {
+            // Arrange
+            const cwd = fixture("integration-scenario");
+
+            // Act
+            const { exitCode, stdout } = await runDoctor(
+                ["--format", "json"],
+                cwd,
+            );
+
+            // Assert
+            expect(exitCode).toBe(1);
+            const report = JSON.parse(stdout) as {
+                findings: Array<{ criterionId: string; severity: string }>;
+            };
+            const critical = report.findings.find(
+                (f) => f.criterionId === "missing-copilot-instructions",
+            );
+            expect(critical).toBeDefined();
+            expect(critical?.severity).toBe("critical");
+        });
+    });
+
+    describe("when run with --summary on the integration-scenario fixture", () => {
+        it("should exit 0 because --summary skips evaluation", async () => {
+            // Arrange
+            const cwd = fixture("integration-scenario");
+
+            // Act
+            const { exitCode } = await runDoctor(["--summary"], cwd);
+
+            // Assert
+            expect(exitCode).toBe(0);
+        });
+    });
+});

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,136 @@
+import { resolve } from "node:path";
+import {
+    CRITERIA,
+    classifyArchetype,
+    createWisdomClient,
+    detectAmbiguities,
+    evaluate,
+    formatSummary,
+    hasBlockingFindings,
+    readIntentArtifact,
+    renderHuman,
+    scanRepository,
+    toJson,
+    WisdomUnavailableError,
+} from "@lousy-agents/agentic-doctor";
+import { defineCommand } from "citty";
+import { createConsola } from "consola";
+
+export const doctorCommand = defineCommand({
+    meta: {
+        name: "doctor",
+        description:
+            "Diagnose agentic configuration across harnesses: inventory, classify, and evaluate preconditions",
+    },
+    args: {
+        summary: {
+            type: "boolean",
+            description: "Show archetype classification only — skip evaluation",
+            default: false,
+        },
+        format: {
+            type: "string",
+            description: "Output format: human (default) or json",
+            default: "human",
+        },
+        ci: {
+            type: "boolean",
+            description: "Force non-interactive mode",
+            default: false,
+        },
+    },
+    async run({ args }) {
+        const logger = createConsola();
+        const repoPath = resolve(process.cwd());
+        const format = args.format === "json" ? "json" : "human";
+
+        const records = await scanRepository(repoPath);
+        const classification = classifyArchetype(records);
+        const summary = formatSummary(records, classification);
+
+        // Load wisdom graph for snapshotRef (gracefully degrade if unavailable)
+        const wisdomDir = resolve(repoPath, "wisdom");
+        let snapshotRef: string | undefined;
+        try {
+            const wisdomClient = createWisdomClient(wisdomDir);
+            const graph = await wisdomClient.getGraph();
+            snapshotRef = graph.snapshotRef;
+        } catch (err) {
+            if (!(err instanceof WisdomUnavailableError)) throw err;
+            logger.debug(
+                "Wisdom graph unavailable — snapshotRef will be omitted",
+            );
+        }
+
+        if (args.summary) {
+            if (format === "json") {
+                process.stdout.write(
+                    `${JSON.stringify(
+                        {
+                            archetype: summary.archetype,
+                            dominanceScore: summary.dominanceScore,
+                            totalRecords: summary.totalRecords,
+                            harnessBreakdown: summary.harnessBreakdown,
+                            crossHarnessEdges: summary.crossHarnessEdges,
+                        },
+                        null,
+                        2,
+                    )}\n`,
+                );
+            } else {
+                renderHuman(summary, [], logger, snapshotRef);
+            }
+            return;
+        }
+
+        if (classification.archetype === "none") {
+            if (format === "json") {
+                process.stdout.write(
+                    `${JSON.stringify(toJson(summary, [], snapshotRef), null, 2)}\n`,
+                );
+            } else {
+                logger.info("No agentic constructs found in the repository.");
+            }
+            return;
+        }
+
+        const intentResult = await readIntentArtifact(repoPath);
+        let intent = intentResult.found ? intentResult.artifact : null;
+
+        // Interactive elicitation when no intent artifact and running in a TTY
+        const isInteractive = !args.ci && process.stdin.isTTY === true;
+        if (intent === null && isInteractive) {
+            const questions = detectAmbiguities(records, classification);
+            for (const q of questions) {
+                logger.info(`\n${q.hint}`);
+                const answer = await logger.prompt(q.question, {
+                    type: "confirm",
+                    initial: false,
+                });
+                if (answer) {
+                    logger.info("  Noted.");
+                }
+            }
+            // After interactive prompts, re-read in case user pre-created the artifact
+            const retried = await readIntentArtifact(repoPath);
+            if (retried.found) intent = retried.artifact;
+        }
+
+        const findings = evaluate(CRITERIA, {
+            records,
+            classification,
+            intent,
+        });
+
+        if (format === "json") {
+            const report = toJson(summary, findings, snapshotRef);
+            process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        } else {
+            renderHuman(summary, findings, logger, snapshotRef);
+        }
+
+        if (hasBlockingFindings(findings)) {
+            process.exitCode = 1;
+        }
+    },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { defineCommand, runMain } from "citty";
 import { captureCommand } from "./commands/capture.js";
 import { createContextCommand } from "./commands/context.js";
 import { copilotSetupCommand } from "./commands/copilot-setup.js";
+import { doctorCommand } from "./commands/doctor.js";
 import { initCommand } from "./commands/init.js";
 import { createInitHooksCommand } from "./commands/init-hooks.js";
 import { createLintCommand } from "./commands/lint.js";
@@ -42,6 +43,7 @@ const main = defineCommand({
         context: contextCmd,
         "init-hooks": initHooksCmd,
         capture: captureCommand,
+        doctor: doctorCommand,
     },
 });
 

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,0 +1,56 @@
+{
+    "name": "@lousy-agents/agentic-doctor",
+    "version": "0.1.0",
+    "description": "Agentic configuration doctor: inventory, classify, and evaluate multi-harness agentic configurations",
+    "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zpratt/lousy-agents.git",
+        "directory": "packages/doctor"
+    },
+    "author": "zpratt",
+    "license": "BSD-2-Clause-Patent",
+    "bugs": {
+        "url": "https://github.com/zpratt/lousy-agents/issues"
+    },
+    "homepage": "https://github.com/zpratt/lousy-agents/tree/main/packages/doctor#readme",
+    "keywords": [
+        "ai",
+        "agentic",
+        "configuration",
+        "doctor",
+        "harness",
+        "copilot",
+        "claude",
+        "codex"
+    ],
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
+    },
+    "files": [
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "default": "./dist/index.js"
+        }
+    },
+    "bin": {
+        "agentic-doctor": "./dist/cli/index.js"
+    },
+    "scripts": {
+        "build": "rspack build --config rspack.config.ts && chmod +x dist/cli/index.js",
+        "test": "vitest run",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "citty": "0.2.2",
+        "consola": "3.4.2",
+        "yaml": "2.9.0",
+        "zod": "4.4.3"
+    },
+    "devDependencies": {
+        "@lousy-agents/core": "*"
+    }
+}

--- a/packages/doctor/rspack.config.ts
+++ b/packages/doctor/rspack.config.ts
@@ -15,6 +15,7 @@ const config: Configuration = {
     mode: "production",
     target: "node",
     entry: {
+        "cli/index": "./src/cli/index.ts",
         index: "./src/index.ts",
     },
     output: {
@@ -37,8 +38,6 @@ const config: Configuration = {
         },
         alias: {
             "@lousy-agents/core": resolve(__dirname, "../core/src"),
-            "@lousy-agents/lint": resolve(__dirname, "../lint/src"),
-            "@lousy-agents/agentic-doctor": resolve(__dirname, "../doctor/src"),
         },
     },
     module: {

--- a/packages/doctor/src/cli/index.ts
+++ b/packages/doctor/src/cli/index.ts
@@ -1,0 +1,132 @@
+import { resolve } from "node:path";
+import { defineCommand, runMain } from "citty";
+import { createConsola } from "consola";
+import {
+    hasBlockingFindings,
+    renderHuman,
+} from "../formatters/human-renderer.js";
+import { toJson } from "../formatters/json-formatter.js";
+import { formatSummary } from "../formatters/summary-formatter.js";
+import { readIntentArtifact } from "../gateways/intent-artifact.js";
+import { scanRepository } from "../gateways/scanner.js";
+import {
+    createWisdomClient,
+    WisdomUnavailableError,
+} from "../gateways/wisdom-client.js";
+import { classifyArchetype } from "../use-cases/classify-archetype.js";
+import { CRITERIA } from "../use-cases/criteria.js";
+import { detectAmbiguities } from "../use-cases/detect-ambiguities.js";
+import { evaluate } from "../use-cases/evaluate-engine.js";
+
+const main = defineCommand({
+    meta: {
+        name: "agentic-doctor",
+        version: "0.1.0",
+        description:
+            "Diagnose agentic configuration across harnesses: inventory, classify, elicit intent, and evaluate preconditions",
+    },
+    args: {
+        summary: {
+            type: "boolean",
+            description: "Show archetype classification only — skip evaluation",
+            default: false,
+        },
+        format: {
+            type: "string",
+            description: "Output format: human (default) or json",
+            default: "human",
+        },
+        ci: {
+            type: "boolean",
+            description:
+                "Force non-interactive mode (skip elicitation prompts, apply conservative inference)",
+            default: false,
+        },
+    },
+    async run({ args }) {
+        const logger = createConsola();
+        const repoPath = resolve(process.cwd());
+        const format = args.format === "json" ? "json" : "human";
+
+        const records = await scanRepository(repoPath);
+        const classification = classifyArchetype(records);
+        const summary = formatSummary(records, classification);
+
+        // Load wisdom graph for snapshotRef (gracefully degrade if unavailable)
+        const wisdomDir = resolve(repoPath, "wisdom");
+        let snapshotRef: string | undefined;
+        try {
+            const wisdomClient = createWisdomClient(wisdomDir);
+            const graph = await wisdomClient.getGraph();
+            snapshotRef = graph.snapshotRef;
+        } catch (err) {
+            if (!(err instanceof WisdomUnavailableError)) throw err;
+            logger.debug(
+                "Wisdom graph unavailable — snapshotRef will be omitted",
+            );
+        }
+
+        if (args.summary) {
+            if (format === "json") {
+                process.stdout.write(
+                    `${JSON.stringify({ archetype: summary.archetype, dominanceScore: summary.dominanceScore, totalRecords: summary.totalRecords, harnessBreakdown: summary.harnessBreakdown, crossHarnessEdges: summary.crossHarnessEdges }, null, 2)}\n`,
+                );
+            } else {
+                renderHuman(summary, [], logger, snapshotRef);
+            }
+            return;
+        }
+
+        if (classification.archetype === "none") {
+            if (format === "json") {
+                process.stdout.write(
+                    `${JSON.stringify(toJson(summary, [], snapshotRef), null, 2)}\n`,
+                );
+            } else {
+                logger.info("No agentic constructs found in the repository.");
+            }
+            return;
+        }
+
+        const intentResult = await readIntentArtifact(repoPath);
+        let intent = intentResult.found ? intentResult.artifact : null;
+
+        // Interactive elicitation when no intent artifact and running in a TTY
+        const isInteractive = !args.ci && process.stdin.isTTY === true;
+        if (intent === null && isInteractive) {
+            const questions = detectAmbiguities(records, classification);
+            for (const q of questions) {
+                logger.info(`\n${q.hint}`);
+                const answer = await logger.prompt(q.question, {
+                    type: "confirm",
+                    initial: false,
+                });
+                if (answer) {
+                    logger.info("  Noted.");
+                }
+            }
+            // After interactive prompts, re-read in case user pre-created the artifact
+            const retried = await readIntentArtifact(repoPath);
+            if (retried.found) intent = retried.artifact;
+        }
+
+        const findings = evaluate(CRITERIA, {
+            records,
+            classification,
+            intent,
+        });
+
+        if (format === "json") {
+            const report = toJson(summary, findings, snapshotRef);
+            process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        } else {
+            renderHuman(summary, findings, logger, snapshotRef);
+        }
+
+        if (hasBlockingFindings(findings)) {
+            process.exitCode = 1;
+        }
+    },
+});
+
+runMain(main);

--- a/packages/doctor/src/entities/archetype.ts
+++ b/packages/doctor/src/entities/archetype.ts
@@ -1,0 +1,13 @@
+export type Archetype =
+    | "pure"
+    | "intentional-hybrid"
+    | "canonical-contract"
+    | "accidental-sprawl"
+    | "none"
+    | "ambiguous";
+
+export interface ArchetypeClassification {
+    archetype: Archetype;
+    dominanceScore: number;
+    ambiguities: string[];
+}

--- a/packages/doctor/src/entities/criteria-schema.ts
+++ b/packages/doctor/src/entities/criteria-schema.ts
@@ -1,0 +1,57 @@
+import type { Archetype } from "./archetype.js";
+import type { FindingCategory, HarnessName } from "./edge-types.js";
+
+export type Severity = "critical" | "high" | "medium" | "low" | "info";
+export type Classification = "defect" | "advisory" | "info";
+
+export type CheckMethod =
+    | "inventory.fileExists"
+    | "inventory.edgePresent"
+    | "inventory.edgeDirection"
+    | "inventory.edgeDirectionExists"
+    | "inventory.archetypeIs"
+    | "inventory.constructPresent"
+    | "intent.capabilityDeclared";
+
+export interface FileExistsArgs {
+    harness: HarnessName;
+    paths: readonly string[];
+}
+
+export interface EdgePresentArgs {
+    fromHarness: HarnessName;
+    toHarness: HarnessName;
+    edgeType?: "hard-import" | "soft-reference" | "glob-binding";
+}
+
+export interface ConstructPresentArgs {
+    harness: HarnessName;
+    constructType: string;
+}
+
+export interface CapabilityDeclaredArgs {
+    capability: string;
+}
+
+export type ArchetypeIsArgs = Record<string, never>;
+
+export type CheckMethodArgs =
+    | FileExistsArgs
+    | EdgePresentArgs
+    | ConstructPresentArgs
+    | CapabilityDeclaredArgs
+    | ArchetypeIsArgs;
+
+export interface Criterion {
+    id: string;
+    appliesToHarness: HarnessName | "all";
+    appliesToArchetype?: Archetype | "all";
+    severity: Severity;
+    classification: Classification;
+    capability?: string;
+    precondition?: string;
+    checkMethod: CheckMethod;
+    checkArgs: CheckMethodArgs;
+    category: FindingCategory;
+    description: string;
+}

--- a/packages/doctor/src/entities/declared-intent.ts
+++ b/packages/doctor/src/entities/declared-intent.ts
@@ -1,0 +1,11 @@
+import type { HarnessName } from "./edge-types.js";
+
+export type IntentSource = "interactive" | "ci-assumed" | "pre-committed";
+
+export interface DeclaredIntentArtifact {
+    targetHarnesses: HarnessName[];
+    desiredCapabilities: string[];
+    confirmedAnswers: Record<string, unknown>;
+    intentSource: IntentSource;
+    snapshotRef?: string;
+}

--- a/packages/doctor/src/entities/edge-types.ts
+++ b/packages/doctor/src/entities/edge-types.ts
@@ -1,0 +1,50 @@
+export type HarnessName =
+    | "claude"
+    | "copilot"
+    | "codex"
+    | "antigravity"
+    | "hermes"
+    | "crush"
+    | "pi"
+    | "shared";
+
+export type ConstructType =
+    | "instruction"
+    | "skill"
+    | "agent"
+    | "subagent"
+    | "mcp-server"
+    | "plugin"
+    | "hook";
+
+export type EdgeType = "hard-import" | "soft-reference" | "glob-binding";
+
+export type FindingCategory =
+    | "missing-required"
+    | "malformed-reference"
+    | "wrong-direction"
+    | "drift"
+    | "governance"
+    | "composition-style";
+
+export interface EdgeDirection {
+    from: string;
+    to: string | string[];
+}
+
+export interface Edge {
+    type: EdgeType;
+    direction: EdgeDirection;
+    target: string;
+    malformed: boolean;
+    reason?: "missing-target" | "path-traversal";
+}
+
+export interface InventoryRecord {
+    id: string;
+    path: string;
+    harness: HarnessName;
+    constructType: ConstructType;
+    loadMechanism: "referenced" | "convention-loaded";
+    edges: Edge[];
+}

--- a/packages/doctor/src/entities/finding.ts
+++ b/packages/doctor/src/entities/finding.ts
@@ -1,0 +1,23 @@
+import type { Classification, Severity } from "./criteria-schema.js";
+import type { FindingCategory } from "./edge-types.js";
+
+export interface CitationHandle {
+    nodeId: string;
+    sourceFile: string;
+    lineRange?: [number, number];
+    snapshotRef?: string;
+}
+
+export interface Finding {
+    id: string;
+    criterionId: string;
+    targetId: string;
+    severity: Severity;
+    category: FindingCategory;
+    classification: Classification;
+    intentGated: boolean;
+    assumedIntent: boolean;
+    description: string;
+    evidenceCitation?: CitationHandle;
+    snapshotRef?: string;
+}

--- a/packages/doctor/src/entities/harness-footprints.test.ts
+++ b/packages/doctor/src/entities/harness-footprints.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { HarnessName } from "./edge-types.js";
+import {
+    getFootprint,
+    HARNESS_FOOTPRINTS,
+    HARNESS_NAMES,
+} from "./harness-footprints.js";
+
+describe("HARNESS_NAMES", () => {
+    it("should export exactly seven active harness names", () => {
+        expect(HARNESS_NAMES).toHaveLength(7);
+    });
+
+    it("should not include 'shared'", () => {
+        expect(HARNESS_NAMES).not.toContain("shared");
+    });
+
+    it("should contain all seven supported harnesses", () => {
+        const expected: HarnessName[] = [
+            "claude",
+            "copilot",
+            "codex",
+            "antigravity",
+            "hermes",
+            "crush",
+            "pi",
+        ];
+        for (const harness of expected) {
+            expect(HARNESS_NAMES).toContain(harness);
+        }
+    });
+});
+
+describe("HARNESS_FOOTPRINTS", () => {
+    it("should have an entry for every harness in HARNESS_NAMES", () => {
+        for (const name of HARNESS_NAMES) {
+            expect(HARNESS_FOOTPRINTS[name]).toBeDefined();
+        }
+    });
+
+    it("should assign a status of 'verified' or 'needs-verification' to every footprint", () => {
+        for (const name of HARNESS_NAMES) {
+            const footprint = HARNESS_FOOTPRINTS[name];
+            expect(["verified", "needs-verification"]).toContain(
+                footprint.status,
+            );
+        }
+    });
+
+    it("should map each cross-reference mechanism to exactly one edge type", () => {
+        const validEdgeTypes = new Set([
+            "hard-import",
+            "soft-reference",
+            "glob-binding",
+        ]);
+        for (const name of HARNESS_NAMES) {
+            const footprint = HARNESS_FOOTPRINTS[name];
+            for (const mechanism of footprint.crossRefMechanisms) {
+                expect(validEdgeTypes).toContain(mechanism.edgeType);
+            }
+        }
+    });
+
+    describe("when harness reads AGENTS.md by convention", () => {
+        it("should set readsAgentsMd: true for codex", () => {
+            expect(HARNESS_FOOTPRINTS.codex.readsAgentsMd).toBe(true);
+        });
+
+        it("should set readsAgentsMd: true for hermes", () => {
+            expect(HARNESS_FOOTPRINTS.hermes.readsAgentsMd).toBe(true);
+        });
+
+        it("should set readsAgentsMd: true for crush", () => {
+            expect(HARNESS_FOOTPRINTS.crush.readsAgentsMd).toBe(true);
+        });
+
+        it("should set readsAgentsMd: true for pi", () => {
+            expect(HARNESS_FOOTPRINTS.pi.readsAgentsMd).toBe(true);
+        });
+    });
+
+    describe("when harness does not read AGENTS.md as primary convention", () => {
+        it("should set readsAgentsMd: false for claude", () => {
+            expect(HARNESS_FOOTPRINTS.claude.readsAgentsMd).toBe(false);
+        });
+
+        it("should set readsAgentsMd: false for copilot", () => {
+            expect(HARNESS_FOOTPRINTS.copilot.readsAgentsMd).toBe(false);
+        });
+    });
+
+    describe("pi harness walk boundary", () => {
+        it("should document that pi has no git boundary (walks to filesystem root)", () => {
+            expect(HARNESS_FOOTPRINTS.pi.walkBoundary).toBe("filesystem-root");
+        });
+    });
+
+    describe("codex harness walk boundary", () => {
+        it("should document that codex stops at git root", () => {
+            expect(HARNESS_FOOTPRINTS.codex.walkBoundary).toBe("git-root");
+        });
+    });
+
+    describe("antigravity/gemini harness", () => {
+        it("should be marked needs-verification", () => {
+            expect(HARNESS_FOOTPRINTS.antigravity.status).toBe(
+                "needs-verification",
+            );
+        });
+    });
+});
+
+describe("getFootprint", () => {
+    it("should return the footprint for a given harness name", () => {
+        const footprint = getFootprint("claude");
+        expect(footprint.name).toBe("claude");
+    });
+
+    it("should return footprints with non-empty conventionFiles lists for harnesses that have them", () => {
+        const claude = getFootprint("claude");
+        expect(claude.conventionFiles.length).toBeGreaterThan(0);
+    });
+});

--- a/packages/doctor/src/entities/harness-footprints.ts
+++ b/packages/doctor/src/entities/harness-footprints.ts
@@ -1,0 +1,220 @@
+import type { EdgeType, HarnessName } from "./edge-types.js";
+
+export interface CrossRefMechanism {
+    edgeType: EdgeType;
+    description: string;
+}
+
+export type FootprintStatus = "verified" | "needs-verification";
+export type WalkBoundary = "git-root" | "filesystem-root" | "project" | null;
+
+export interface HarnessFootprint {
+    name: HarnessName;
+    status: FootprintStatus;
+    readsAgentsMd: boolean;
+    walkBoundary: WalkBoundary;
+    conventionFiles: readonly string[];
+    conventionDirs: readonly string[];
+    crossRefMechanisms: readonly CrossRefMechanism[];
+    /**
+     * Patterns used to detect whether a file belongs to this harness.
+     * Each entry is either:
+     *   - An exact repo-relative path (e.g. "CLAUDE.md")
+     *   - A directory prefix ending with "/" (e.g. ".claude/") — matches any
+     *     file whose path starts with that prefix
+     * A file is assigned this harness when exactly one harness's primary
+     * indicators match. Two or more matches → "shared".
+     */
+    primaryIndicators: readonly string[];
+}
+
+export const HARNESS_NAMES: readonly HarnessName[] = [
+    "claude",
+    "copilot",
+    "codex",
+    "antigravity",
+    "hermes",
+    "crush",
+    "pi",
+] as const;
+
+export const HARNESS_FOOTPRINTS: Readonly<
+    Record<HarnessName, HarnessFootprint>
+> = {
+    claude: {
+        name: "claude",
+        status: "verified",
+        readsAgentsMd: false,
+        walkBoundary: "git-root",
+        conventionFiles: ["CLAUDE.md"],
+        conventionDirs: [".claude/"],
+        primaryIndicators: ["CLAUDE.md", ".claude/"],
+        crossRefMechanisms: [
+            {
+                edgeType: "hard-import",
+                description:
+                    "Claude @path/to/file syntax at line start inlines the referenced file",
+            },
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    copilot: {
+        name: "copilot",
+        status: "verified",
+        readsAgentsMd: false,
+        walkBoundary: "project",
+        conventionFiles: [".github/copilot-instructions.md"],
+        conventionDirs: [".github/instructions/"],
+        primaryIndicators: [
+            ".github/copilot-instructions.md",
+            ".github/instructions/",
+        ],
+        crossRefMechanisms: [
+            {
+                edgeType: "glob-binding",
+                description:
+                    "Copilot applyTo frontmatter field scopes an instruction to matching source files",
+            },
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    codex: {
+        name: "codex",
+        status: "verified",
+        readsAgentsMd: true,
+        walkBoundary: "git-root",
+        conventionFiles: ["AGENTS.md", "AGENTS.override.md"],
+        conventionDirs: [".codex/", ".agents/skills/", ".codex-plugin/"],
+        primaryIndicators: [
+            "AGENTS.override.md",
+            ".codex/",
+            ".agents/skills/",
+            ".codex-plugin/",
+        ],
+        crossRefMechanisms: [
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    antigravity: {
+        name: "antigravity",
+        status: "needs-verification",
+        readsAgentsMd: false,
+        walkBoundary: null,
+        conventionFiles: ["GEMINI.md"],
+        conventionDirs: [".gemini/"],
+        primaryIndicators: ["GEMINI.md", ".gemini/"],
+        crossRefMechanisms: [
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    hermes: {
+        name: "hermes",
+        status: "verified",
+        readsAgentsMd: true,
+        walkBoundary: "git-root",
+        conventionFiles: [
+            ".hermes.md",
+            "HERMES.md",
+            "AGENTS.md",
+            "agents.md",
+            "CLAUDE.md",
+            "claude.md",
+            ".cursorrules",
+            "SOUL.md",
+        ],
+        conventionDirs: [],
+        primaryIndicators: [".hermes.md", "HERMES.md", "SOUL.md"],
+        crossRefMechanisms: [
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    crush: {
+        name: "crush",
+        status: "verified",
+        readsAgentsMd: true,
+        walkBoundary: null,
+        conventionFiles: ["AGENTS.md", "crush.json"],
+        conventionDirs: [".crush/", ".agents/skills/"],
+        primaryIndicators: ["crush.json", ".crush/"],
+        crossRefMechanisms: [
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    pi: {
+        name: "pi",
+        status: "verified",
+        readsAgentsMd: true,
+        walkBoundary: "filesystem-root",
+        conventionFiles: ["AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"],
+        conventionDirs: [".pi/", ".pi/skills/", ".pi/prompts/"],
+        primaryIndicators: [".pi/", ".pi/skills/", ".pi/prompts/"],
+        crossRefMechanisms: [
+            {
+                edgeType: "soft-reference",
+                description:
+                    "Frontmatter see:/references:/requires: keys or markdown links to sibling instruction files",
+            },
+        ],
+    },
+
+    shared: {
+        name: "shared",
+        status: "verified",
+        readsAgentsMd: true,
+        walkBoundary: null,
+        conventionFiles: ["AGENTS.md", "AGENTS.MD", "agents.md"],
+        conventionDirs: [],
+        primaryIndicators: ["AGENTS.md", "AGENTS.MD", "agents.md"],
+        crossRefMechanisms: [],
+    },
+};
+
+export function getFootprint(harness: HarnessName): HarnessFootprint {
+    return HARNESS_FOOTPRINTS[harness];
+}
+
+export function matchesPrimaryIndicator(
+    repoRelativePath: string,
+    indicators: readonly string[],
+): boolean {
+    const normalized = repoRelativePath.replace(/\\/g, "/");
+    return indicators.some((indicator) => {
+        if (indicator.endsWith("/")) {
+            return (
+                normalized === indicator.slice(0, -1) ||
+                normalized.startsWith(indicator)
+            );
+        }
+        return normalized === indicator;
+    });
+}

--- a/packages/doctor/src/formatters/human-renderer.ts
+++ b/packages/doctor/src/formatters/human-renderer.ts
@@ -1,0 +1,93 @@
+import type { ConsolaInstance } from "consola";
+import type { Severity } from "../entities/criteria-schema.js";
+import type { FindingCategory } from "../entities/edge-types.js";
+import type { Finding } from "../entities/finding.js";
+import type { SummaryOutput } from "./summary-formatter.js";
+
+const SEVERITY_ORDER: Severity[] = [
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "info",
+];
+
+const CATEGORY_ORDER: FindingCategory[] = [
+    "missing-required",
+    "malformed-reference",
+    "wrong-direction",
+    "drift",
+    "governance",
+    "composition-style",
+];
+
+function sortFindings(findings: Finding[]): Finding[] {
+    return [...findings].sort((a, b) => {
+        const severityDiff =
+            SEVERITY_ORDER.indexOf(a.severity) -
+            SEVERITY_ORDER.indexOf(b.severity);
+        if (severityDiff !== 0) return severityDiff;
+        return (
+            CATEGORY_ORDER.indexOf(a.category) -
+            CATEGORY_ORDER.indexOf(b.category)
+        );
+    });
+}
+
+export function renderHuman(
+    summary: SummaryOutput,
+    findings: Finding[],
+    logger: ConsolaInstance,
+    snapshotRef?: string,
+): void {
+    if (snapshotRef) {
+        logger.info(`Evidence snapshot: ${snapshotRef}`);
+    }
+
+    logger.info(`Archetype: ${summary.archetype}`);
+    logger.info(`  ${summary.archetypeDescription}`);
+    logger.info(
+        `  Dominance score: ${(summary.dominanceScore * 100).toFixed(0)}%`,
+    );
+    logger.info(`  Total records: ${summary.totalRecords}`);
+
+    if (summary.harnessBreakdown.length > 0) {
+        logger.info("  Harness breakdown:");
+        for (const { harness, count } of summary.harnessBreakdown) {
+            logger.info(`    ${harness}: ${count}`);
+        }
+    }
+
+    if (summary.crossHarnessEdges > 0) {
+        logger.info(`  Cross-harness edges: ${summary.crossHarnessEdges}`);
+    }
+
+    if (findings.length === 0) {
+        logger.success("No findings.");
+        return;
+    }
+
+    logger.info(`\nFindings (${findings.length}):`);
+    const sorted = sortFindings(findings);
+    for (const finding of sorted) {
+        const severityTag = `[${finding.severity.toUpperCase()}]`;
+        const classTag = `[${finding.classification}]`;
+        const assumedTag = finding.assumedIntent ? " [assumed intent]" : "";
+        logger.info(
+            `  ${severityTag}${classTag} ${finding.criterionId}: ${finding.description}${assumedTag}`,
+        );
+        if (finding.evidenceCitation) {
+            logger.info(
+                `    Evidence: node ${finding.evidenceCitation.nodeId} (${finding.evidenceCitation.sourceFile})`,
+            );
+        }
+    }
+}
+
+export function hasBlockingFindings(findings: Finding[]): boolean {
+    return findings.some(
+        (f) =>
+            (f.severity === "critical" || f.severity === "high") &&
+            f.classification === "defect",
+    );
+}

--- a/packages/doctor/src/formatters/json-formatter.ts
+++ b/packages/doctor/src/formatters/json-formatter.ts
@@ -1,0 +1,29 @@
+import type { Archetype } from "../entities/archetype.js";
+import type { Finding } from "../entities/finding.js";
+import type { SummaryOutput } from "./summary-formatter.js";
+
+export interface ReportJson {
+    archetype: Archetype;
+    dominanceScore: number;
+    totalRecords: number;
+    harnessBreakdown: Array<{ harness: string; count: number }>;
+    crossHarnessEdges: number;
+    findings: Finding[];
+    snapshotRef?: string;
+}
+
+export function toJson(
+    summary: SummaryOutput,
+    findings: Finding[],
+    snapshotRef?: string,
+): ReportJson {
+    return {
+        archetype: summary.archetype,
+        dominanceScore: summary.dominanceScore,
+        totalRecords: summary.totalRecords,
+        harnessBreakdown: summary.harnessBreakdown,
+        crossHarnessEdges: summary.crossHarnessEdges,
+        findings,
+        ...(snapshotRef !== undefined ? { snapshotRef } : {}),
+    };
+}

--- a/packages/doctor/src/formatters/summary-formatter.ts
+++ b/packages/doctor/src/formatters/summary-formatter.ts
@@ -1,0 +1,69 @@
+import type { ArchetypeClassification } from "../entities/archetype.js";
+import type { InventoryRecord } from "../entities/edge-types.js";
+
+const ARCHETYPE_DESCRIPTIONS: Record<
+    ArchetypeClassification["archetype"],
+    string
+> = {
+    pure: "Single-harness configuration. One AI coding assistant dominates the repository.",
+    "intentional-hybrid":
+        "Multi-harness configuration with cross-harness references. Harnesses deliberately share context.",
+    "canonical-contract":
+        "Shared AGENTS.md contract. All harnesses read from a single canonical instruction file.",
+    "accidental-sprawl":
+        "Multiple harnesses configured without cross-referencing. May indicate legacy or uncoordinated setup.",
+    none: "No agentic configuration detected.",
+    ambiguous: "Configuration does not fit a single archetype cleanly.",
+};
+
+export interface SummaryOutput {
+    archetype: ArchetypeClassification["archetype"];
+    archetypeDescription: string;
+    dominanceScore: number;
+    totalRecords: number;
+    harnessBreakdown: Array<{ harness: string; count: number }>;
+    crossHarnessEdges: number;
+}
+
+export function formatSummary(
+    records: InventoryRecord[],
+    classification: ArchetypeClassification,
+): SummaryOutput {
+    const counts = new Map<string, number>();
+    for (const r of records) {
+        counts.set(r.harness, (counts.get(r.harness) ?? 0) + 1);
+    }
+
+    const harnessBreakdown = Array.from(counts.entries())
+        .map(([harness, count]) => ({ harness, count }))
+        .sort((a, b) => a.harness.localeCompare(b.harness));
+
+    let crossHarnessEdges = 0;
+    const harnessByPath = new Map<string, string>();
+    for (const r of records) {
+        harnessByPath.set(r.path, r.harness);
+    }
+    for (const r of records) {
+        for (const edge of r.edges) {
+            if (
+                !edge.malformed &&
+                edge.type !== "glob-binding" &&
+                typeof edge.direction.to === "string"
+            ) {
+                const targetHarness = harnessByPath.get(edge.direction.to);
+                if (targetHarness && targetHarness !== r.harness) {
+                    crossHarnessEdges++;
+                }
+            }
+        }
+    }
+
+    return {
+        archetype: classification.archetype,
+        archetypeDescription: ARCHETYPE_DESCRIPTIONS[classification.archetype],
+        dominanceScore: classification.dominanceScore,
+        totalRecords: records.length,
+        harnessBreakdown,
+        crossHarnessEdges,
+    };
+}

--- a/packages/doctor/src/gateways/intent-artifact.ts
+++ b/packages/doctor/src/gateways/intent-artifact.ts
@@ -1,0 +1,101 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import {
+    readTextWithinRoot,
+    resolveSafePath,
+} from "@lousy-agents/core/gateways/file-system-utils.js";
+import { z } from "zod";
+import type { DeclaredIntentArtifact } from "../entities/declared-intent.js";
+import type { HarnessName } from "../entities/edge-types.js";
+
+const MAX_INTENT_BYTES = 65_536;
+
+const ARTIFACT_FILENAME = "intent.json";
+const ARTIFACT_DIR = ".agentic-doctor";
+
+const DeclaredIntentSchema = z.object({
+    targetHarnesses: z.array(
+        z.enum([
+            "claude",
+            "copilot",
+            "codex",
+            "antigravity",
+            "hermes",
+            "crush",
+            "pi",
+            "shared",
+        ]),
+    ),
+    desiredCapabilities: z.array(z.string()),
+    confirmedAnswers: z.record(z.string(), z.unknown()),
+    intentSource: z.enum(["interactive", "ci-assumed", "pre-committed"]),
+    snapshotRef: z.string().optional(),
+});
+
+export interface IntentArtifactResult {
+    found: true;
+    artifact: DeclaredIntentArtifact;
+    path: string;
+}
+
+export interface IntentArtifactMissing {
+    found: false;
+}
+
+export type ReadIntentResult = IntentArtifactResult | IntentArtifactMissing;
+
+export async function readIntentArtifact(
+    repoRoot: string,
+): Promise<ReadIntentResult> {
+    const artifactRelPath = `${ARTIFACT_DIR}/${ARTIFACT_FILENAME}`;
+    const artifactPath = resolve(repoRoot, ARTIFACT_DIR, ARTIFACT_FILENAME);
+
+    let raw: string;
+    try {
+        raw = await readTextWithinRoot(
+            repoRoot,
+            artifactRelPath,
+            MAX_INTENT_BYTES,
+        );
+    } catch {
+        return { found: false };
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return { found: false };
+    }
+
+    const result = DeclaredIntentSchema.safeParse(parsed);
+    if (!result.success) {
+        return { found: false };
+    }
+
+    return { found: true, artifact: result.data, path: artifactPath };
+}
+
+export async function writeIntentArtifact(
+    repoRoot: string,
+    artifact: DeclaredIntentArtifact,
+): Promise<string> {
+    const artifactPath = await resolveSafePath(
+        repoRoot,
+        `${ARTIFACT_DIR}/${ARTIFACT_FILENAME}`,
+    );
+    await mkdir(dirname(artifactPath), { recursive: true });
+    await writeFile(artifactPath, JSON.stringify(artifact, null, 2), "utf-8");
+    return artifactPath;
+}
+
+export function buildDefaultIntent(
+    harnesses: HarnessName[],
+): DeclaredIntentArtifact {
+    return {
+        targetHarnesses: harnesses.filter((h) => h !== "shared"),
+        desiredCapabilities: [],
+        confirmedAnswers: {},
+        intentSource: "ci-assumed",
+    };
+}

--- a/packages/doctor/src/gateways/scanner.test.ts
+++ b/packages/doctor/src/gateways/scanner.test.ts
@@ -1,0 +1,192 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { scanRepository } from "./scanner.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "../../tests/fixtures");
+
+function fixture(name: string): string {
+    return resolve(fixturesDir, name);
+}
+
+describe("scanRepository", () => {
+    describe("when scanning a pure-claude repository", () => {
+        it("should return one convention-loaded instruction record with harness 'claude'", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+
+            const claudeRecords = records.filter((r) => r.harness === "claude");
+            expect(claudeRecords).toHaveLength(1);
+            expect(claudeRecords[0].loadMechanism).toBe("convention-loaded");
+            expect(claudeRecords[0].constructType).toBe("instruction");
+        });
+
+        it("should assign id in '${harness}:${path}' format", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+            for (const r of records) {
+                expect(r.id).toMatch(/^[a-z-]+:.+/);
+            }
+        });
+
+        it("should return no edges", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+            const allEdges = records.flatMap((r) => r.edges);
+            expect(allEdges).toHaveLength(0);
+        });
+    });
+
+    describe("when scanning an intentional-hybrid repository", () => {
+        it("should detect a soft-reference edge from CLAUDE.md to the Copilot instruction file", async () => {
+            const records = await scanRepository(fixture("intentional-hybrid"));
+
+            const claudeRecord = records.find(
+                (r) => r.harness === "claude" && r.path.endsWith("CLAUDE.md"),
+            );
+            expect(claudeRecord).toBeDefined();
+
+            const softRef = claudeRecord?.edges.find(
+                (e) => e.type === "soft-reference",
+            );
+            expect(softRef).toBeDefined();
+            expect(softRef?.direction.from).toContain("CLAUDE.md");
+            expect(softRef?.direction.to).toContain("services.instructions.md");
+        });
+
+        it("should detect a hard-import edge from CLAUDE.md to the Copilot instruction file", async () => {
+            const records = await scanRepository(fixture("intentional-hybrid"));
+
+            const claudeRecord = records.find(
+                (r) => r.harness === "claude" && r.path.endsWith("CLAUDE.md"),
+            );
+            expect(claudeRecord).toBeDefined();
+
+            const hardImport = claudeRecord?.edges.find(
+                (e) => e.type === "hard-import",
+            );
+            expect(hardImport).toBeDefined();
+            expect(hardImport?.malformed).toBe(false);
+        });
+
+        it("should assign referenced load mechanism to targets named by an inbound edge", async () => {
+            const records = await scanRepository(fixture("intentional-hybrid"));
+
+            const servicesRecord = records.find((r) =>
+                r.path.endsWith("services.instructions.md"),
+            );
+            expect(servicesRecord).toBeDefined();
+            expect(servicesRecord?.loadMechanism).toBe("referenced");
+        });
+    });
+
+    describe("when scanning an accidental-sprawl repository", () => {
+        it("should return zero cross-harness hard-import or soft-reference edges", async () => {
+            const records = await scanRepository(fixture("accidental-sprawl"));
+
+            const crossHarnessEdges = records.flatMap((r) =>
+                r.edges.filter(
+                    (e) =>
+                        (e.type === "hard-import" ||
+                            e.type === "soft-reference") &&
+                        !e.malformed,
+                ),
+            );
+            expect(crossHarnessEdges).toHaveLength(0);
+        });
+
+        it("should discover both claude and copilot constructs", async () => {
+            const records = await scanRepository(fixture("accidental-sprawl"));
+
+            const harnesses = new Set(records.map((r) => r.harness));
+            expect(harnesses).toContain("claude");
+            expect(harnesses).toContain("copilot");
+        });
+    });
+
+    describe("when scanning a canonical-contract repository", () => {
+        it("should discover AGENTS.md with harness 'shared'", async () => {
+            const records = await scanRepository(fixture("canonical-contract"));
+
+            const agentsMd = records.find((r) => r.path.endsWith("AGENTS.md"));
+            expect(agentsMd).toBeDefined();
+            expect(agentsMd?.harness).toBe("shared");
+        });
+
+        it("should assign id as 'shared:AGENTS.md'", async () => {
+            const records = await scanRepository(fixture("canonical-contract"));
+
+            const agentsMd = records.find((r) => r.path.endsWith("AGENTS.md"));
+            expect(agentsMd?.id).toBe("shared:AGENTS.md");
+        });
+    });
+
+    describe("when scanning a repository with an empty-repo fixture", () => {
+        it("should return an empty inventory", async () => {
+            const records = await scanRepository(fixture("empty-repo"));
+            expect(records).toHaveLength(0);
+        });
+    });
+
+    describe("when scanning a repository with a malformed edge", () => {
+        it("should record the edge as malformed with reason 'missing-target'", async () => {
+            const records = await scanRepository(fixture("malformed-edge"));
+
+            const claudeRecord = records.find(
+                (r) => r.harness === "claude" && r.path.endsWith("CLAUDE.md"),
+            );
+            expect(claudeRecord).toBeDefined();
+
+            const malformedEdge = claudeRecord?.edges.find(
+                (e) => e.malformed && e.reason === "missing-target",
+            );
+            expect(malformedEdge).toBeDefined();
+        });
+
+        it("should retain malformed edges in the inventory", async () => {
+            const records = await scanRepository(fixture("malformed-edge"));
+
+            const allEdges = records.flatMap((r) => r.edges);
+            expect(allEdges.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe("when scanning a repository with a path-traversal reference", () => {
+        it("should record the edge as malformed with reason 'path-traversal'", async () => {
+            const records = await scanRepository(fixture("path-traversal"));
+
+            const allEdges = records.flatMap((r) => r.edges);
+            const traversalEdge = allEdges.find(
+                (e) => e.malformed && e.reason === "path-traversal",
+            );
+            expect(traversalEdge).toBeDefined();
+        });
+
+        it("should not read the file at the outside-root path", async () => {
+            await expect(
+                scanRepository(fixture("path-traversal")),
+            ).resolves.not.toThrow();
+        });
+    });
+
+    describe("InventoryRecord id format", () => {
+        it("should produce ids matching the ${harness}:${path} pattern for all records", async () => {
+            const records = await scanRepository(fixture("accidental-sprawl"));
+
+            for (const r of records) {
+                expect(r.id).toMatch(/^[a-z-]+:.+/);
+                expect(r.id.startsWith(`${r.harness}:`)).toBe(true);
+            }
+        });
+    });
+
+    describe("EdgeDirection fields", () => {
+        it("should set non-empty from and to on all edges in intentional-hybrid fixture", async () => {
+            const records = await scanRepository(fixture("intentional-hybrid"));
+
+            const allEdges = records.flatMap((r) => r.edges);
+            for (const edge of allEdges) {
+                expect(edge.direction.from).toBeTruthy();
+                expect(edge.direction.to).toBeTruthy();
+            }
+        });
+    });
+});

--- a/packages/doctor/src/gateways/scanner.ts
+++ b/packages/doctor/src/gateways/scanner.ts
@@ -1,0 +1,267 @@
+import { dirname, relative, resolve, sep } from "node:path";
+import {
+    listDirectoryWithinRoot,
+    readTextWithinRoot,
+} from "@lousy-agents/core/gateways/file-system-utils.js";
+import type {
+    ConstructType,
+    Edge,
+    HarnessName,
+    InventoryRecord,
+} from "../entities/edge-types.js";
+import {
+    HARNESS_FOOTPRINTS,
+    HARNESS_NAMES,
+    matchesPrimaryIndicator,
+} from "../entities/harness-footprints.js";
+import { parseRawEdges } from "../lib/edge-parser.js";
+
+const MAX_FILE_BYTES = 1_048_576;
+
+const SCANNABLE_EXTENSIONS = new Set([
+    ".md",
+    ".mdc",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+]);
+
+// Extensionless files that are known harness convention artifacts
+const SCANNABLE_EXTENSIONLESS = new Set([".cursorrules"]);
+
+const ALL_HARNESS_NAMES: readonly HarnessName[] = [...HARNESS_NAMES, "shared"];
+
+function isScannableFile(name: string): boolean {
+    if (SCANNABLE_EXTENSIONLESS.has(name)) return true;
+    const dot = name.lastIndexOf(".");
+    if (dot === -1) return false;
+    return SCANNABLE_EXTENSIONS.has(name.slice(dot));
+}
+
+function isMarkdownFile(name: string): boolean {
+    return name.endsWith(".md") || name.endsWith(".mdc");
+}
+
+function determineConstructType(relPath: string): ConstructType {
+    if (
+        relPath.startsWith(".agents/skills/") ||
+        relPath.startsWith(".pi/skills/") ||
+        relPath.startsWith(".pi/prompts/")
+    ) {
+        return "skill";
+    }
+    if (relPath.startsWith(".codex-plugin/")) {
+        return "plugin";
+    }
+    if (relPath.startsWith(".claude/hooks/")) {
+        return "hook";
+    }
+    if (relPath.startsWith(".claude/commands/")) {
+        return "agent";
+    }
+    return "instruction";
+}
+
+function determineHarness(repoRelativePath: string): HarnessName | null {
+    const matching = ALL_HARNESS_NAMES.filter((harness) =>
+        matchesPrimaryIndicator(
+            repoRelativePath,
+            HARNESS_FOOTPRINTS[harness].primaryIndicators,
+        ),
+    );
+    if (matching.length === 0) return null;
+    if (matching.length >= 2) return "shared";
+    return matching[0];
+}
+
+function resolveEdge(
+    rawTarget: string,
+    type: "hard-import" | "soft-reference" | "glob-binding",
+    sourceAbsPath: string,
+    repoRoot: string,
+    existingAbsPaths: Set<string>,
+): Edge {
+    const from = relative(repoRoot, sourceAbsPath).replace(/\\/g, "/");
+
+    if (type === "glob-binding") {
+        return {
+            type,
+            direction: { from, to: rawTarget },
+            target: rawTarget,
+            malformed: false,
+        };
+    }
+
+    const sourceDir = dirname(sourceAbsPath);
+    const resolvedAbs = resolve(sourceDir, rawTarget);
+    const absoluteRoot = resolve(repoRoot);
+
+    const isWithinRoot =
+        resolvedAbs === absoluteRoot ||
+        resolvedAbs.startsWith(`${absoluteRoot}${sep}`);
+
+    if (!isWithinRoot) {
+        return {
+            type,
+            direction: { from, to: rawTarget },
+            target: rawTarget,
+            malformed: true,
+            reason: "path-traversal",
+        };
+    }
+
+    const relativeTarget = relative(absoluteRoot, resolvedAbs).replace(
+        /\\/g,
+        "/",
+    );
+
+    if (!existingAbsPaths.has(resolvedAbs)) {
+        return {
+            type,
+            direction: { from, to: relativeTarget },
+            target: relativeTarget,
+            malformed: true,
+            reason: "missing-target",
+        };
+    }
+
+    return {
+        type,
+        direction: { from, to: relativeTarget },
+        target: relativeTarget,
+        malformed: false,
+    };
+}
+
+async function collectFiles(
+    repoRoot: string,
+    relDir: string,
+    collected: Array<{ absPath: string; relPath: string }>,
+    depth = 0,
+): Promise<void> {
+    if (depth > 10) return;
+
+    let entries: Awaited<ReturnType<typeof listDirectoryWithinRoot>>;
+    try {
+        entries = await listDirectoryWithinRoot(repoRoot, relDir);
+    } catch {
+        return;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+        const entryRel = relDir ? `${relDir}/${entry.name}` : entry.name;
+        const entryAbs = resolve(repoRoot, entryRel);
+
+        if (entry.isDirectory()) {
+            if (
+                entry.name === "node_modules" ||
+                entry.name === ".git" ||
+                entry.name === "dist"
+            ) {
+                continue;
+            }
+            await collectFiles(repoRoot, entryRel, collected, depth + 1);
+        } else if (entry.isFile() && isScannableFile(entry.name)) {
+            collected.push({ absPath: entryAbs, relPath: entryRel });
+        }
+    }
+}
+
+export async function scanRepository(
+    repoRoot: string,
+): Promise<InventoryRecord[]> {
+    const absRoot = resolve(repoRoot);
+
+    const allFiles: Array<{ absPath: string; relPath: string }> = [];
+    await collectFiles(absRoot, "", allFiles);
+
+    const existingAbsPaths = new Set(allFiles.map((f) => f.absPath));
+
+    const rawRecords: Array<{
+        absPath: string;
+        relPath: string;
+        harness: HarnessName;
+        content: string | null;
+    }> = [];
+
+    for (const { absPath, relPath } of allFiles) {
+        const harness = determineHarness(relPath);
+        if (harness === null) continue;
+
+        let content: string | null = null;
+        if (isMarkdownFile(relPath)) {
+            try {
+                content = await readTextWithinRoot(
+                    absRoot,
+                    relPath,
+                    MAX_FILE_BYTES,
+                );
+            } catch {
+                content = null;
+            }
+        }
+
+        rawRecords.push({ absPath, relPath, harness, content });
+    }
+
+    const records: InventoryRecord[] = rawRecords.map(
+        ({ absPath, relPath, harness, content }) => {
+            const edges: Edge[] = [];
+
+            if (content !== null) {
+                const rawEdges = parseRawEdges(content);
+                for (const raw of rawEdges) {
+                    edges.push(
+                        resolveEdge(
+                            raw.rawTarget,
+                            raw.type,
+                            absPath,
+                            absRoot,
+                            existingAbsPaths,
+                        ),
+                    );
+                }
+            }
+
+            const id =
+                harness === "shared"
+                    ? `shared:${relPath}`
+                    : `${harness}:${relPath}`;
+
+            return {
+                id,
+                path: relPath,
+                harness,
+                constructType: determineConstructType(relPath),
+                loadMechanism: "convention-loaded" as const,
+                edges,
+            };
+        },
+    );
+
+    const referencedPaths = new Set<string>();
+    for (const record of records) {
+        for (const edge of record.edges) {
+            if (
+                !edge.malformed &&
+                edge.type !== "glob-binding" &&
+                typeof edge.direction.to === "string"
+            ) {
+                referencedPaths.add(edge.direction.to);
+            }
+        }
+    }
+
+    for (const record of records) {
+        if (referencedPaths.has(record.path)) {
+            (
+                record as { loadMechanism: "referenced" | "convention-loaded" }
+            ).loadMechanism = "referenced";
+        }
+    }
+
+    return records;
+}

--- a/packages/doctor/src/gateways/wisdom-client.test.ts
+++ b/packages/doctor/src/gateways/wisdom-client.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWisdomClient, WisdomUnavailableError } from "./wisdom-client.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tmpDir = resolve(__dirname, "../../tests/fixtures/.tmp-wisdom");
+const graphifyDir = resolve(tmpDir, "graphify-out");
+
+async function writeGraph(data: unknown): Promise<void> {
+    await mkdir(graphifyDir, { recursive: true });
+    await writeFile(
+        resolve(graphifyDir, "graph.json"),
+        JSON.stringify(data),
+        "utf-8",
+    );
+}
+
+describe("WisdomClient", () => {
+    beforeEach(async () => {
+        await mkdir(graphifyDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    describe("getGraph", () => {
+        it("should return parsed graph when graph.json exists", async () => {
+            const graph = { nodes: [{ id: "n1" }], edges: [] };
+            await writeGraph(graph);
+
+            const client = createWisdomClient(tmpDir);
+            const result = await client.getGraph();
+
+            expect(result.nodes).toHaveLength(1);
+            expect(result.nodes[0].id).toBe("n1");
+        });
+
+        it("should throw WisdomUnavailableError when graph.json is missing", async () => {
+            const client = createWisdomClient("/nonexistent-dir");
+            await expect(client.getGraph()).rejects.toBeInstanceOf(
+                WisdomUnavailableError,
+            );
+        });
+
+        it("should throw WisdomUnavailableError when graph.json is invalid JSON", async () => {
+            await mkdir(graphifyDir, { recursive: true });
+            await writeFile(
+                resolve(graphifyDir, "graph.json"),
+                "not-valid-json",
+                "utf-8",
+            );
+
+            const client = createWisdomClient(tmpDir);
+            await expect(client.getGraph()).rejects.toBeInstanceOf(
+                WisdomUnavailableError,
+            );
+        });
+
+        it("should throw WisdomUnavailableError when nodes array is missing", async () => {
+            await writeGraph({ edges: [] });
+
+            const client = createWisdomClient(tmpDir);
+            await expect(client.getGraph()).rejects.toBeInstanceOf(
+                WisdomUnavailableError,
+            );
+        });
+
+        it("should normalize missing edges to an empty array", async () => {
+            await writeGraph({ nodes: [{ id: "n1" }] });
+
+            const client = createWisdomClient(tmpDir);
+            const result = await client.getGraph();
+
+            expect(result.edges).toEqual([]);
+        });
+    });
+
+    describe("findNodeById", () => {
+        it("should return node when it exists", async () => {
+            await writeGraph({
+                nodes: [{ id: "copilot-instructions", label: "Copilot" }],
+                edges: [],
+            });
+
+            const client = createWisdomClient(tmpDir);
+            const node = await client.findNodeById("copilot-instructions");
+
+            expect(node).not.toBeNull();
+            expect(node?.id).toBe("copilot-instructions");
+        });
+
+        it("should return null when node does not exist", async () => {
+            await writeGraph({ nodes: [], edges: [] });
+
+            const client = createWisdomClient(tmpDir);
+            const node = await client.findNodeById("nonexistent");
+
+            expect(node).toBeNull();
+        });
+    });
+});

--- a/packages/doctor/src/gateways/wisdom-client.ts
+++ b/packages/doctor/src/gateways/wisdom-client.ts
@@ -1,0 +1,75 @@
+import { readTextWithinRoot } from "@lousy-agents/core/gateways/file-system-utils.js";
+import { z } from "zod";
+
+const MAX_GRAPH_BYTES = 10_485_760;
+
+export class WisdomUnavailableError extends Error {
+    constructor(reason: string) {
+        super(`Wisdom graph unavailable: ${reason}`);
+        this.name = "WisdomUnavailableError";
+    }
+}
+
+const WisdomNodeSchema = z
+    .object({
+        id: z.string(),
+        label: z.string().optional(),
+        description: z.string().optional(),
+        sourceFile: z.string().optional(),
+        lineStart: z.number().int().min(1).optional().catch(undefined),
+        lineEnd: z.number().int().min(1).optional().catch(undefined),
+    })
+    .passthrough();
+
+const WisdomGraphSchema = z.object({
+    nodes: z.array(WisdomNodeSchema),
+    edges: z.array(z.unknown()).default([]),
+    snapshotRef: z.string().optional(),
+});
+
+export type WisdomNode = z.infer<typeof WisdomNodeSchema>;
+export type WisdomGraph = z.infer<typeof WisdomGraphSchema>;
+
+export interface WisdomClient {
+    getGraph(): Promise<WisdomGraph>;
+    findNodeById(nodeId: string): Promise<WisdomNode | null>;
+}
+
+export function createWisdomClient(wisdomDir: string): WisdomClient {
+    async function getGraph(): Promise<WisdomGraph> {
+        let raw: string;
+        try {
+            raw = await readTextWithinRoot(
+                wisdomDir,
+                "graphify-out/graph.json",
+                MAX_GRAPH_BYTES,
+            );
+        } catch {
+            throw new WisdomUnavailableError(
+                "graph.json not found in wisdom directory — ensure the wisdom submodule is initialized",
+            );
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(raw);
+        } catch {
+            throw new WisdomUnavailableError("graph.json is not valid JSON");
+        }
+
+        try {
+            return WisdomGraphSchema.parse(parsed);
+        } catch {
+            throw new WisdomUnavailableError(
+                "graph.json does not match expected schema (nodes must be an array with id strings)",
+            );
+        }
+    }
+
+    async function findNodeById(nodeId: string): Promise<WisdomNode | null> {
+        const graph = await getGraph();
+        return graph.nodes.find((n) => n.id === nodeId) ?? null;
+    }
+
+    return { getGraph, findNodeById };
+}

--- a/packages/doctor/src/gateways/wisdom-evidence.ts
+++ b/packages/doctor/src/gateways/wisdom-evidence.ts
@@ -1,0 +1,87 @@
+import { resolve, sep } from "node:path";
+import { readTextWithinRoot } from "@lousy-agents/core/gateways/file-system-utils.js";
+import type { CitationHandle } from "../entities/finding.js";
+import type { WisdomClient } from "./wisdom-client.js";
+import { WisdomUnavailableError } from "./wisdom-client.js";
+
+const MAX_EVIDENCE_BYTES = 1_048_576;
+
+export interface EvidencePassage {
+    citation: CitationHandle;
+    text: string;
+}
+
+export async function resolveEvidence(
+    nodeId: string,
+    wisdomDir: string,
+    client: WisdomClient,
+): Promise<EvidencePassage> {
+    const node = await client.findNodeById(nodeId);
+    if (!node) {
+        throw new WisdomUnavailableError(`node '${nodeId}' not found in graph`);
+    }
+
+    if (!node.sourceFile || typeof node.sourceFile !== "string") {
+        throw new WisdomUnavailableError(
+            `node '${nodeId}' has no sourceFile reference`,
+        );
+    }
+
+    const absoluteWisdomDir = resolve(wisdomDir);
+    const absSourcePath = resolve(absoluteWisdomDir, node.sourceFile);
+
+    const isWithinWisdomDirLexical =
+        absSourcePath === absoluteWisdomDir ||
+        absSourcePath.startsWith(`${absoluteWisdomDir}${sep}`);
+
+    if (!isWithinWisdomDirLexical) {
+        throw new WisdomUnavailableError(
+            `source file '${node.sourceFile}' escapes wisdom directory — path traversal rejected`,
+        );
+    }
+
+    let fileContent: string;
+    try {
+        fileContent = await readTextWithinRoot(
+            absoluteWisdomDir,
+            node.sourceFile,
+            MAX_EVIDENCE_BYTES,
+        );
+    } catch {
+        throw new WisdomUnavailableError(
+            `source file '${node.sourceFile}' not found`,
+        );
+    }
+
+    const lineStart = node.lineStart;
+    const lineEnd = node.lineEnd;
+    let text: string;
+
+    if (
+        typeof lineStart === "number" &&
+        typeof lineEnd === "number" &&
+        lineEnd >= lineStart
+    ) {
+        const lines = fileContent.split("\n");
+        text = lines.slice(lineStart - 1, lineEnd).join("\n");
+    } else {
+        text = fileContent;
+    }
+
+    const snapshotRef =
+        typeof node.snapshotRef === "string" ? node.snapshotRef : undefined;
+
+    const citation: CitationHandle = {
+        nodeId,
+        sourceFile: node.sourceFile,
+        lineRange:
+            typeof lineStart === "number" &&
+            typeof lineEnd === "number" &&
+            lineEnd >= lineStart
+                ? [lineStart, lineEnd]
+                : undefined,
+        snapshotRef,
+    };
+
+    return { citation, text };
+}

--- a/packages/doctor/src/index.ts
+++ b/packages/doctor/src/index.ts
@@ -1,0 +1,28 @@
+export type {
+    Archetype,
+    ArchetypeClassification,
+} from "./entities/archetype.js";
+export type { Criterion } from "./entities/criteria-schema.js";
+export type { DeclaredIntentArtifact } from "./entities/declared-intent.js";
+export type { InventoryRecord } from "./entities/edge-types.js";
+export type { Finding } from "./entities/finding.js";
+export {
+    hasBlockingFindings,
+    renderHuman,
+} from "./formatters/human-renderer.js";
+export { toJson } from "./formatters/json-formatter.js";
+export { formatSummary } from "./formatters/summary-formatter.js";
+export {
+    buildDefaultIntent,
+    readIntentArtifact,
+    writeIntentArtifact,
+} from "./gateways/intent-artifact.js";
+export { scanRepository } from "./gateways/scanner.js";
+export {
+    createWisdomClient,
+    WisdomUnavailableError,
+} from "./gateways/wisdom-client.js";
+export { classifyArchetype } from "./use-cases/classify-archetype.js";
+export { CRITERIA } from "./use-cases/criteria.js";
+export { detectAmbiguities } from "./use-cases/detect-ambiguities.js";
+export { evaluate } from "./use-cases/evaluate-engine.js";

--- a/packages/doctor/src/lib/edge-parser.ts
+++ b/packages/doctor/src/lib/edge-parser.ts
@@ -1,0 +1,97 @@
+import { parse as parseYaml } from "yaml";
+
+const HARD_IMPORT_GLOBAL_RE = /^@([^\s@][^\s]*)/gm;
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+const MARKDOWN_LINK_RE = /\[(?:[^\]]*)\]\(([^)]+)\)/g;
+const SOFT_REF_FRONTMATTER_KEYS = ["see", "references", "requires"] as const;
+
+interface ParsedFrontmatter {
+    applyTo?: string | string[];
+    see?: string | string[];
+    references?: string | string[];
+    requires?: string | string[];
+    [key: string]: unknown;
+}
+
+function parseFrontmatter(content: string): ParsedFrontmatter | null {
+    const match = FRONTMATTER_RE.exec(content);
+    if (!match) return null;
+    try {
+        const parsed = parseYaml(match[1]);
+        return typeof parsed === "object" && parsed !== null
+            ? (parsed as ParsedFrontmatter)
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function contentWithoutFrontmatter(content: string): string {
+    return content.replace(FRONTMATTER_RE, "");
+}
+
+function toStringArray(value: unknown): string[] {
+    if (typeof value === "string") return [value];
+    if (Array.isArray(value))
+        return value.filter((v): v is string => typeof v === "string");
+    return [];
+}
+
+function isInstructionFilePath(path: string): boolean {
+    return (
+        path.endsWith(".md") ||
+        path.endsWith(".instructions.md") ||
+        path.endsWith(".mdc")
+    );
+}
+
+export interface RawEdge {
+    type: "hard-import" | "soft-reference" | "glob-binding";
+    rawTarget: string;
+}
+
+export function parseRawEdges(content: string): RawEdge[] {
+    const edges: RawEdge[] = [];
+    const fm = parseFrontmatter(content);
+
+    if (fm) {
+        if (fm.applyTo) {
+            for (const glob of toStringArray(fm.applyTo)) {
+                edges.push({ type: "glob-binding", rawTarget: glob });
+            }
+        }
+
+        for (const key of SOFT_REF_FRONTMATTER_KEYS) {
+            const value = fm[key];
+            if (value) {
+                for (const ref of toStringArray(value)) {
+                    if (isInstructionFilePath(ref)) {
+                        edges.push({ type: "soft-reference", rawTarget: ref });
+                    }
+                }
+            }
+        }
+    }
+
+    const body = fm ? contentWithoutFrontmatter(content) : content;
+
+    for (const match of body.matchAll(HARD_IMPORT_GLOBAL_RE)) {
+        const target = match[1];
+        if (target.includes("/")) {
+            edges.push({ type: "hard-import", rawTarget: target });
+        }
+    }
+
+    for (const match of body.matchAll(MARKDOWN_LINK_RE)) {
+        const href = match[1];
+        if (
+            !href.startsWith("http://") &&
+            !href.startsWith("https://") &&
+            isInstructionFilePath(href)
+        ) {
+            edges.push({ type: "soft-reference", rawTarget: href });
+        }
+    }
+
+    return edges;
+}

--- a/packages/doctor/src/use-cases/classify-archetype.test.ts
+++ b/packages/doctor/src/use-cases/classify-archetype.test.ts
@@ -1,0 +1,78 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { scanRepository } from "../gateways/scanner.js";
+import { classifyArchetype } from "./classify-archetype.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "../../tests/fixtures");
+
+function fixture(name: string): string {
+    return resolve(fixturesDir, name);
+}
+
+describe("classifyArchetype", () => {
+    describe("when given a pure-claude repository", () => {
+        it("should classify as 'pure'", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+            const result = classifyArchetype(records);
+            expect(result.archetype).toBe("pure");
+        });
+
+        it("should set dominanceScore >= 0.80", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+            const result = classifyArchetype(records);
+            expect(result.dominanceScore).toBeGreaterThanOrEqual(0.8);
+        });
+
+        it("should return no ambiguities", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+            const result = classifyArchetype(records);
+            expect(result.ambiguities).toHaveLength(0);
+        });
+    });
+
+    describe("when given an intentional-hybrid repository", () => {
+        it("should classify as 'intentional-hybrid'", async () => {
+            const records = await scanRepository(fixture("intentional-hybrid"));
+            const result = classifyArchetype(records);
+            expect(result.archetype).toBe("intentional-hybrid");
+        });
+
+        it("should have a dominanceScore < 1.0", async () => {
+            const records = await scanRepository(fixture("intentional-hybrid"));
+            const result = classifyArchetype(records);
+            expect(result.dominanceScore).toBeLessThan(1.0);
+        });
+    });
+
+    describe("when given an accidental-sprawl repository", () => {
+        it("should classify as 'accidental-sprawl'", async () => {
+            const records = await scanRepository(fixture("accidental-sprawl"));
+            const result = classifyArchetype(records);
+            expect(result.archetype).toBe("accidental-sprawl");
+        });
+    });
+
+    describe("when given a canonical-contract repository", () => {
+        it("should classify as 'canonical-contract'", async () => {
+            const records = await scanRepository(fixture("canonical-contract"));
+            const result = classifyArchetype(records);
+            expect(result.archetype).toBe("canonical-contract");
+        });
+    });
+
+    describe("when given an empty repository", () => {
+        it("should classify as 'none'", async () => {
+            const records = await scanRepository(fixture("empty-repo"));
+            const result = classifyArchetype(records);
+            expect(result.archetype).toBe("none");
+        });
+
+        it("should have dominanceScore of 0", async () => {
+            const records = await scanRepository(fixture("empty-repo"));
+            const result = classifyArchetype(records);
+            expect(result.dominanceScore).toBe(0);
+        });
+    });
+});

--- a/packages/doctor/src/use-cases/classify-archetype.ts
+++ b/packages/doctor/src/use-cases/classify-archetype.ts
@@ -1,0 +1,127 @@
+import type {
+    Archetype,
+    ArchetypeClassification,
+} from "../entities/archetype.js";
+import type { InventoryRecord } from "../entities/edge-types.js";
+import { HARNESS_FOOTPRINTS } from "../entities/harness-footprints.js";
+import {
+    buildHarnessProfiles,
+    PURE_DOMINANCE_THRESHOLD,
+} from "./harness-profile.js";
+
+export type { Archetype, ArchetypeClassification };
+
+function hasCrossHarnessEdges(records: InventoryRecord[]): boolean {
+    const harnessByPath = new Map<string, string>();
+    for (const record of records) {
+        harnessByPath.set(record.path, record.harness);
+    }
+
+    for (const record of records) {
+        for (const edge of record.edges) {
+            if (
+                edge.malformed ||
+                edge.type === "glob-binding" ||
+                typeof edge.direction.to !== "string"
+            ) {
+                continue;
+            }
+            const targetHarness = harnessByPath.get(edge.direction.to);
+            if (targetHarness && targetHarness !== record.harness) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+export function classifyArchetype(
+    records: InventoryRecord[],
+): ArchetypeClassification {
+    if (records.length === 0) {
+        return { archetype: "none", dominanceScore: 0, ambiguities: [] };
+    }
+
+    const profiles = buildHarnessProfiles(records);
+    const distinctHarnesses = new Set(records.map((r) => r.harness));
+
+    if (distinctHarnesses.size === 1 && distinctHarnesses.has("shared")) {
+        return {
+            archetype: "canonical-contract",
+            dominanceScore: 1,
+            ambiguities: [],
+        };
+    }
+
+    const nonSharedHarnesses = [...distinctHarnesses].filter(
+        (h) => h !== "shared",
+    );
+
+    const needsVerificationHarnesses = nonSharedHarnesses.filter(
+        (h) =>
+            HARNESS_FOOTPRINTS[h as keyof typeof HARNESS_FOOTPRINTS].status ===
+            "needs-verification",
+    );
+    const ambiguities = needsVerificationHarnesses.map(
+        (h) => `harness '${h}' detection patterns are not fully verified`,
+    );
+
+    // If all non-shared harnesses need verification, the archetype is ambiguous
+    if (
+        nonSharedHarnesses.length > 0 &&
+        needsVerificationHarnesses.length === nonSharedHarnesses.length
+    ) {
+        const topProfile = profiles.reduce((a, b) =>
+            a.share > b.share ? a : b,
+        );
+        return {
+            archetype: "ambiguous",
+            dominanceScore: topProfile.share,
+            ambiguities,
+        };
+    }
+
+    // pure: single dominant harness with no cross-harness edges
+    if (nonSharedHarnesses.length === 1) {
+        const dominant = profiles.find(
+            (p) => p.harness === nonSharedHarnesses[0],
+        );
+        const score = dominant?.share ?? 1;
+        if (
+            score >= PURE_DOMINANCE_THRESHOLD &&
+            !hasCrossHarnessEdges(records)
+        ) {
+            return {
+                archetype: "pure",
+                dominanceScore: score,
+                ambiguities,
+            };
+        }
+    }
+
+    const crossHarness = hasCrossHarnessEdges(records);
+    const topProfile = profiles.reduce((a, b) => (a.share > b.share ? a : b));
+
+    if (crossHarness) {
+        return {
+            archetype: "intentional-hybrid",
+            dominanceScore: topProfile.share,
+            ambiguities,
+        };
+    }
+
+    // ambiguous when needs-verification harnesses are present alongside verified ones
+    if (ambiguities.length > 0) {
+        return {
+            archetype: "ambiguous",
+            dominanceScore: topProfile.share,
+            ambiguities,
+        };
+    }
+
+    return {
+        archetype: "accidental-sprawl",
+        dominanceScore: topProfile.share,
+        ambiguities,
+    };
+}

--- a/packages/doctor/src/use-cases/criteria.test.ts
+++ b/packages/doctor/src/use-cases/criteria.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { CRITERIA } from "./criteria.js";
+
+describe("CRITERIA", () => {
+    it("should be a non-empty array", () => {
+        expect(CRITERIA.length).toBeGreaterThan(0);
+    });
+
+    it("should include missing-copilot-instructions as critical defect", () => {
+        const criterion = CRITERIA.find(
+            (c) => c.id === "missing-copilot-instructions",
+        );
+        expect(criterion).toBeDefined();
+        expect(criterion?.severity).toBe("critical");
+        expect(criterion?.classification).toBe("defect");
+        expect(criterion?.category).toBe("missing-required");
+    });
+
+    it("should include missing-intent-artifact as medium defect", () => {
+        const criterion = CRITERIA.find(
+            (c) => c.id === "missing-intent-artifact",
+        );
+        expect(criterion).toBeDefined();
+        expect(criterion?.severity).toBe("medium");
+        expect(criterion?.classification).toBe("defect");
+        expect(criterion?.category).toBe("governance");
+    });
+
+    it("should have unique ids for all criteria", () => {
+        const ids = CRITERIA.map((c) => c.id);
+        const unique = new Set(ids);
+        expect(unique.size).toBe(ids.length);
+    });
+
+    it("should have valid checkMethod on all criteria", () => {
+        const validMethods = new Set([
+            "inventory.fileExists",
+            "inventory.edgePresent",
+            "inventory.edgeDirection",
+            "inventory.edgeDirectionExists",
+            "inventory.archetypeIs",
+            "inventory.constructPresent",
+            "intent.capabilityDeclared",
+        ]);
+        for (const criterion of CRITERIA) {
+            expect(validMethods.has(criterion.checkMethod)).toBe(true);
+        }
+    });
+});

--- a/packages/doctor/src/use-cases/criteria.ts
+++ b/packages/doctor/src/use-cases/criteria.ts
@@ -1,0 +1,129 @@
+import type { Criterion } from "../entities/criteria-schema.js";
+
+export const CRITERIA: readonly Criterion[] = [
+    {
+        id: "missing-copilot-instructions",
+        appliesToHarness: "copilot",
+        severity: "critical",
+        classification: "defect",
+        category: "missing-required",
+        description:
+            "GitHub Copilot requires .github/copilot-instructions.md to load workspace instructions. Without it, Copilot operates without any project-specific context.",
+        capability: "copilot-workspace-instructions",
+        checkMethod: "inventory.fileExists",
+        checkArgs: {
+            harness: "copilot",
+            paths: [".github/copilot-instructions.md"],
+        },
+    },
+    {
+        id: "missing-intent-artifact",
+        appliesToHarness: "all",
+        severity: "medium",
+        classification: "defect",
+        category: "governance",
+        description:
+            "No declared intent artifact found at .agentic-doctor/intent.json. Without declared intent, the doctor cannot evaluate capability preconditions.",
+        checkMethod: "inventory.constructPresent",
+        checkArgs: {
+            harness: "claude",
+            constructType: "instruction",
+        },
+    },
+    {
+        id: "malformed-claude-import",
+        appliesToHarness: "claude",
+        severity: "high",
+        classification: "defect",
+        category: "malformed-reference",
+        description:
+            "A Claude @import reference points to a file that does not exist or escapes the repository root.",
+        checkMethod: "inventory.edgePresent",
+        checkArgs: {
+            fromHarness: "claude",
+            toHarness: "claude",
+            edgeType: "hard-import",
+        },
+    },
+    {
+        id: "cross-harness-drift",
+        appliesToHarness: "all",
+        appliesToArchetype: "accidental-sprawl",
+        severity: "high",
+        classification: "advisory",
+        category: "drift",
+        description:
+            "Multiple AI harnesses are configured but share no cross-harness references. This may indicate accidental configuration sprawl rather than intentional multi-harness setup.",
+        checkMethod: "inventory.archetypeIs",
+        checkArgs: {},
+    },
+    {
+        id: "wrong-direction-copilot-imports-claude",
+        appliesToHarness: "copilot",
+        severity: "medium",
+        classification: "advisory",
+        category: "wrong-direction",
+        description:
+            "A Copilot instruction file references a Claude instruction file. Copilot does not process @import directives, so this reference has no effect and may indicate copy-paste drift.",
+        checkMethod: "inventory.edgeDirectionExists",
+        checkArgs: {
+            fromHarness: "copilot",
+            toHarness: "claude",
+        },
+    },
+    {
+        id: "missing-claude-md",
+        appliesToHarness: "claude",
+        severity: "high",
+        classification: "defect",
+        category: "missing-required",
+        description:
+            "Claude Code requires CLAUDE.md or .claude/ directory to load project instructions.",
+        checkMethod: "inventory.fileExists",
+        checkArgs: {
+            harness: "claude",
+            paths: ["CLAUDE.md", ".claude/"],
+        },
+    },
+    {
+        id: "missing-agents-md",
+        appliesToHarness: "codex",
+        severity: "high",
+        classification: "defect",
+        category: "missing-required",
+        description:
+            "Codex/OpenAI Codex requires AGENTS.md to load project instructions.",
+        checkMethod: "inventory.fileExists",
+        checkArgs: {
+            harness: "codex",
+            paths: ["AGENTS.md", "AGENTS.override.md"],
+        },
+    },
+    {
+        id: "missing-hermes-config",
+        appliesToHarness: "hermes",
+        severity: "medium",
+        classification: "advisory",
+        category: "missing-required",
+        description:
+            "Hermes does not have a primary configuration file (.hermes.md or HERMES.md).",
+        checkMethod: "inventory.fileExists",
+        checkArgs: {
+            harness: "hermes",
+            paths: [".hermes.md", "HERMES.md"],
+        },
+    },
+    {
+        id: "missing-crush-config",
+        appliesToHarness: "crush",
+        severity: "medium",
+        classification: "advisory",
+        category: "missing-required",
+        description: "Crush does not have a crush.json configuration file.",
+        checkMethod: "inventory.fileExists",
+        checkArgs: {
+            harness: "crush",
+            paths: ["crush.json"],
+        },
+    },
+] as const;

--- a/packages/doctor/src/use-cases/detect-ambiguities.ts
+++ b/packages/doctor/src/use-cases/detect-ambiguities.ts
@@ -1,0 +1,52 @@
+import type { ArchetypeClassification } from "../entities/archetype.js";
+import type { InventoryRecord } from "../entities/edge-types.js";
+
+export interface AmbiguityQuestion {
+    id: string;
+    question: string;
+    hint: string;
+}
+
+export function detectAmbiguities(
+    records: InventoryRecord[],
+    classification: ArchetypeClassification,
+): AmbiguityQuestion[] {
+    const questions: AmbiguityQuestion[] = [];
+
+    if (classification.archetype === "accidental-sprawl") {
+        const harnesses = [...new Set(records.map((r) => r.harness))].filter(
+            (h) => h !== "shared",
+        );
+        if (harnesses.length > 1) {
+            questions.push({
+                id: "intended-multi-harness",
+                question: `Multiple AI harnesses are configured (${harnesses.join(", ")}). Is this intentional?`,
+                hint: "Answer 'yes' if you want multiple harnesses to work together. Answer 'no' if this is legacy configuration.",
+            });
+        }
+    }
+
+    if (classification.archetype === "intentional-hybrid") {
+        const pathToHarness = new Map(records.map((r) => [r.path, r.harness]));
+        const hasCrossHarnessImports = records.some((r) =>
+            r.edges.some(
+                (e) =>
+                    !e.malformed &&
+                    e.type === "hard-import" &&
+                    typeof e.direction.to === "string" &&
+                    pathToHarness.has(e.direction.to) &&
+                    pathToHarness.get(e.direction.to) !== r.harness,
+            ),
+        );
+        if (hasCrossHarnessImports) {
+            questions.push({
+                id: "hard-import-intentional",
+                question:
+                    "Claude hard-imports (@path) are referencing instruction files from other harnesses. Is this intentional?",
+                hint: "Hard imports cause Claude to inline the file contents at runtime.",
+            });
+        }
+    }
+
+    return questions;
+}

--- a/packages/doctor/src/use-cases/evaluate-engine.test.ts
+++ b/packages/doctor/src/use-cases/evaluate-engine.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+import type { ArchetypeClassification } from "../entities/archetype.js";
+import type { InventoryRecord } from "../entities/edge-types.js";
+import { CRITERIA } from "./criteria.js";
+import { evaluate } from "./evaluate-engine.js";
+
+function makeRecord(
+    overrides: Partial<InventoryRecord> & {
+        harness: InventoryRecord["harness"];
+    },
+): InventoryRecord {
+    return {
+        id: `${overrides.harness}:test.md`,
+        path: "test.md",
+        constructType: "instruction",
+        loadMechanism: "convention-loaded",
+        edges: [],
+        ...overrides,
+    };
+}
+
+function makeClassification(
+    archetype: ArchetypeClassification["archetype"],
+): ArchetypeClassification {
+    return { archetype, dominanceScore: 1, ambiguities: [] };
+}
+
+describe("evaluate", () => {
+    describe("missing-copilot-instructions criterion", () => {
+        it("should produce a critical finding when copilot records exist but not copilot-instructions.md", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/instructions/services.instructions.md",
+                    id: "copilot:.github/instructions/services.instructions.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "missing-copilot-instructions",
+            );
+            expect(finding).toBeDefined();
+            expect(finding?.severity).toBe("critical");
+        });
+
+        it("should not produce a finding when copilot-instructions.md is present", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "missing-copilot-instructions",
+            );
+            expect(finding).toBeUndefined();
+        });
+    });
+
+    describe("missing-intent-artifact criterion", () => {
+        it("should produce a medium finding when records exist but intent is null", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "missing-intent-artifact",
+            );
+            expect(finding).toBeDefined();
+            expect(finding?.severity).toBe("medium");
+        });
+
+        it("should not produce a finding when intent artifact is present", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: {
+                    targetHarnesses: ["claude"],
+                    desiredCapabilities: [],
+                    confirmedAnswers: {},
+                    intentSource: "pre-committed",
+                },
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "missing-intent-artifact",
+            );
+            expect(finding).toBeUndefined();
+        });
+
+        it("should not produce a finding when there are no records", () => {
+            const findings = evaluate(CRITERIA, {
+                records: [],
+                classification: makeClassification("none"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "missing-intent-artifact",
+            );
+            expect(finding).toBeUndefined();
+        });
+    });
+
+    describe("malformed-claude-import criterion (inventory.edgePresent)", () => {
+        it("should produce a high finding when claude records have malformed hard-import edges", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                    edges: [
+                        {
+                            type: "hard-import",
+                            direction: {
+                                from: "CLAUDE.md",
+                                to: "../outside.md",
+                            },
+                            target: "../outside.md",
+                            malformed: true,
+                            reason: "path-traversal",
+                        },
+                    ],
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "malformed-claude-import",
+            );
+            expect(finding).toBeDefined();
+            expect(finding?.severity).toBe("high");
+            expect(finding?.targetId).toBe("claude:malformed");
+        });
+
+        it("should not produce a finding when copilot (not claude) records have malformed edges", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [
+                        {
+                            type: "soft-reference",
+                            direction: {
+                                from: ".github/copilot-instructions.md",
+                                to: "../outside.md",
+                            },
+                            target: "../outside.md",
+                            malformed: true,
+                            reason: "path-traversal",
+                        },
+                    ],
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "malformed-claude-import",
+            );
+            expect(finding).toBeUndefined();
+        });
+
+        it("should not produce a finding when claude records have no malformed edges", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                    edges: [],
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "malformed-claude-import",
+            );
+            expect(finding).toBeUndefined();
+        });
+    });
+
+    describe("cross-harness-drift criterion (inventory.archetypeIs)", () => {
+        it("should produce a finding for any accidental-sprawl archetype", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                    edges: [],
+                }),
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [],
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("accidental-sprawl"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "cross-harness-drift",
+            );
+            expect(finding).toBeDefined();
+            expect(finding?.severity).toBe("high");
+            expect(finding?.targetId).toBe("all:accidental-sprawl");
+        });
+
+        it("should produce a finding even when cross-harness edges exist, given archetype is accidental-sprawl", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                    edges: [
+                        {
+                            type: "soft-reference",
+                            direction: {
+                                from: "CLAUDE.md",
+                                to: ".github/copilot-instructions.md",
+                            },
+                            target: ".github/copilot-instructions.md",
+                            malformed: false,
+                        },
+                    ],
+                }),
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [],
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("accidental-sprawl"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "cross-harness-drift",
+            );
+            expect(finding).toBeDefined();
+        });
+
+        it("should not produce a cross-harness-drift finding for non-accidental-sprawl archetypes", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                    edges: [],
+                }),
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [],
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("intentional-hybrid"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "cross-harness-drift",
+            );
+            expect(finding).toBeUndefined();
+        });
+    });
+
+    describe("finding id format", () => {
+        it("should produce ids in ${criterionId}:${targetId} format", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("pure"),
+                intent: null,
+            });
+
+            for (const finding of findings) {
+                expect(finding.id).toContain(":");
+                expect(finding.id.startsWith(finding.criterionId)).toBe(true);
+            }
+        });
+    });
+});

--- a/packages/doctor/src/use-cases/evaluate-engine.ts
+++ b/packages/doctor/src/use-cases/evaluate-engine.ts
@@ -1,0 +1,332 @@
+import type { ArchetypeClassification } from "../entities/archetype.js";
+import type {
+    Criterion,
+    EdgePresentArgs,
+    FileExistsArgs,
+} from "../entities/criteria-schema.js";
+import type { DeclaredIntentArtifact } from "../entities/declared-intent.js";
+import type { InventoryRecord } from "../entities/edge-types.js";
+import type { Finding } from "../entities/finding.js";
+
+interface EvaluationContext {
+    records: InventoryRecord[];
+    classification: ArchetypeClassification;
+    intent: DeclaredIntentArtifact | null;
+}
+
+function makeId(criterionId: string, targetId: string): string {
+    return `${criterionId}:${targetId}`;
+}
+
+function checkFileExists(
+    criterion: Criterion,
+    args: FileExistsArgs,
+    ctx: EvaluationContext,
+): Finding[] {
+    const { harness, paths } = args;
+
+    const anyMatch = ctx.records.some((r) =>
+        paths.some(
+            (p) =>
+                r.path === p ||
+                r.path.startsWith(p.endsWith("/") ? p : `${p}/`),
+        ),
+    );
+
+    if (!anyMatch) {
+        return [
+            {
+                id: makeId(criterion.id, `${harness}:all`),
+                criterionId: criterion.id,
+                targetId: `${harness}:all`,
+                severity: criterion.severity,
+                category: criterion.category,
+                classification: criterion.classification,
+                intentGated: false,
+                assumedIntent: false,
+                description: criterion.description,
+            },
+        ];
+    }
+
+    return [];
+}
+
+function checkConstructPresent(
+    criterion: Criterion,
+    ctx: EvaluationContext,
+): Finding[] {
+    const hasRecords = ctx.records.length > 0;
+    const hasIntent = ctx.intent !== null;
+
+    if (hasRecords && !hasIntent) {
+        return [
+            {
+                id: makeId(criterion.id, "all:intent"),
+                criterionId: criterion.id,
+                targetId: "all:intent",
+                severity: criterion.severity,
+                category: criterion.category,
+                classification: criterion.classification,
+                intentGated: false,
+                assumedIntent: true,
+                description: criterion.description,
+            },
+        ];
+    }
+
+    return [];
+}
+
+function checkEdgePresent(
+    criterion: Criterion,
+    args: EdgePresentArgs,
+    ctx: EvaluationContext,
+): Finding[] {
+    const fromRecords = ctx.records.filter(
+        (r) => r.harness === args.fromHarness,
+    );
+
+    const hasMalformedEdges = fromRecords.some((r) =>
+        r.edges.some(
+            (e) =>
+                e.malformed &&
+                (args.edgeType === undefined || e.type === args.edgeType),
+        ),
+    );
+
+    if (hasMalformedEdges) {
+        return [
+            {
+                id: makeId(criterion.id, `${args.fromHarness}:malformed`),
+                criterionId: criterion.id,
+                targetId: `${args.fromHarness}:malformed`,
+                severity: criterion.severity,
+                category: criterion.category,
+                classification: criterion.classification,
+                intentGated: false,
+                assumedIntent: false,
+                description: criterion.description,
+            },
+        ];
+    }
+
+    return [];
+}
+
+function checkEdgeDirection(
+    criterion: Criterion,
+    args: EdgePresentArgs,
+    ctx: EvaluationContext,
+): Finding[] {
+    const fromRecords = ctx.records.filter(
+        (r) => r.harness === args.fromHarness,
+    );
+    const toRecords = ctx.records.filter((r) => r.harness === args.toHarness);
+    const toPaths = new Set(toRecords.map((r) => r.path));
+
+    const hasDirectedEdge = fromRecords.some((r) =>
+        r.edges.some(
+            (e) =>
+                !e.malformed &&
+                (args.edgeType === undefined || e.type === args.edgeType) &&
+                typeof e.direction.to === "string" &&
+                toPaths.has(e.direction.to),
+        ),
+    );
+
+    if (!hasDirectedEdge) {
+        return [
+            {
+                id: makeId(
+                    criterion.id,
+                    `${args.fromHarness}:${args.toHarness}`,
+                ),
+                criterionId: criterion.id,
+                targetId: `${args.fromHarness}:${args.toHarness}`,
+                severity: criterion.severity,
+                category: criterion.category,
+                classification: criterion.classification,
+                intentGated: false,
+                assumedIntent: false,
+                description: criterion.description,
+            },
+        ];
+    }
+
+    return [];
+}
+
+function checkArchetypeIs(
+    criterion: Criterion,
+    ctx: EvaluationContext,
+): Finding[] {
+    return [
+        {
+            id: makeId(criterion.id, `all:${ctx.classification.archetype}`),
+            criterionId: criterion.id,
+            targetId: `all:${ctx.classification.archetype}`,
+            severity: criterion.severity,
+            category: criterion.category,
+            classification: criterion.classification,
+            intentGated: false,
+            assumedIntent: false,
+            description: criterion.description,
+        },
+    ];
+}
+
+function checkEdgeDirectionExists(
+    criterion: Criterion,
+    args: EdgePresentArgs,
+    ctx: EvaluationContext,
+): Finding[] {
+    const fromRecords = ctx.records.filter(
+        (r) => r.harness === args.fromHarness,
+    );
+    const toRecords = ctx.records.filter((r) => r.harness === args.toHarness);
+    const toPaths = new Set(toRecords.map((r) => r.path));
+
+    const hasEdge = fromRecords.some((r) =>
+        r.edges.some(
+            (e) =>
+                !e.malformed &&
+                (args.edgeType === undefined || e.type === args.edgeType) &&
+                typeof e.direction.to === "string" &&
+                toPaths.has(e.direction.to),
+        ),
+    );
+
+    if (hasEdge) {
+        return [
+            {
+                id: makeId(
+                    criterion.id,
+                    `${args.fromHarness}:${args.toHarness}`,
+                ),
+                criterionId: criterion.id,
+                targetId: `${args.fromHarness}:${args.toHarness}`,
+                severity: criterion.severity,
+                category: criterion.category,
+                classification: criterion.classification,
+                intentGated: false,
+                assumedIntent: false,
+                description: criterion.description,
+            },
+        ];
+    }
+
+    return [];
+}
+
+function checkCapabilityDeclared(
+    criterion: Criterion,
+    ctx: EvaluationContext,
+): Finding[] {
+    if (!criterion.capability || ctx.intent === null) return [];
+
+    const isDeclared = ctx.intent.desiredCapabilities.includes(
+        criterion.capability,
+    );
+    if (!isDeclared) {
+        return [
+            {
+                id: makeId(criterion.id, `all:${criterion.capability}`),
+                criterionId: criterion.id,
+                targetId: `all:${criterion.capability}`,
+                severity: criterion.severity,
+                category: criterion.category,
+                classification: criterion.classification,
+                intentGated: true,
+                assumedIntent: false,
+                description: criterion.description,
+            },
+        ];
+    }
+
+    return [];
+}
+
+export function evaluate(
+    criteria: readonly Criterion[],
+    ctx: EvaluationContext,
+): Finding[] {
+    const findings: Finding[] = [];
+
+    for (const criterion of criteria) {
+        if (
+            criterion.appliesToArchetype &&
+            criterion.appliesToArchetype !== "all" &&
+            ctx.classification.archetype !== criterion.appliesToArchetype
+        ) {
+            continue;
+        }
+
+        const harnesses = new Set(ctx.records.map((r) => r.harness));
+        if (
+            criterion.appliesToHarness !== "all" &&
+            !harnesses.has(criterion.appliesToHarness)
+        ) {
+            continue;
+        }
+
+        switch (criterion.checkMethod) {
+            case "inventory.fileExists": {
+                findings.push(
+                    ...checkFileExists(
+                        criterion,
+                        criterion.checkArgs as FileExistsArgs,
+                        ctx,
+                    ),
+                );
+                break;
+            }
+            case "inventory.constructPresent": {
+                findings.push(...checkConstructPresent(criterion, ctx));
+                break;
+            }
+            case "inventory.edgePresent": {
+                findings.push(
+                    ...checkEdgePresent(
+                        criterion,
+                        criterion.checkArgs as EdgePresentArgs,
+                        ctx,
+                    ),
+                );
+                break;
+            }
+            case "inventory.edgeDirection": {
+                findings.push(
+                    ...checkEdgeDirection(
+                        criterion,
+                        criterion.checkArgs as EdgePresentArgs,
+                        ctx,
+                    ),
+                );
+                break;
+            }
+            case "inventory.archetypeIs": {
+                findings.push(...checkArchetypeIs(criterion, ctx));
+                break;
+            }
+            case "inventory.edgeDirectionExists": {
+                findings.push(
+                    ...checkEdgeDirectionExists(
+                        criterion,
+                        criterion.checkArgs as EdgePresentArgs,
+                        ctx,
+                    ),
+                );
+                break;
+            }
+            case "intent.capabilityDeclared": {
+                findings.push(...checkCapabilityDeclared(criterion, ctx));
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    return findings;
+}

--- a/packages/doctor/src/use-cases/harness-profile.ts
+++ b/packages/doctor/src/use-cases/harness-profile.ts
@@ -1,0 +1,37 @@
+import type { InventoryRecord } from "../entities/edge-types.js";
+
+export const PURE_DOMINANCE_THRESHOLD = 0.8;
+
+export interface HarnessProfile {
+    harness: string;
+    recordCount: number;
+    edgeCount: number;
+    share: number;
+}
+
+export function buildHarnessProfiles(
+    records: InventoryRecord[],
+): HarnessProfile[] {
+    if (records.length === 0) return [];
+
+    const data = new Map<string, { records: number; edges: number }>();
+    for (const record of records) {
+        const existing = data.get(record.harness) ?? { records: 0, edges: 0 };
+        data.set(record.harness, {
+            records: existing.records + 1,
+            edges: existing.edges + record.edges.length,
+        });
+    }
+
+    const totalWeight = records.reduce((acc, r) => acc + 1 + r.edges.length, 0);
+
+    return Array.from(data.entries()).map(
+        ([harness, { records: recordCount, edges: edgeCount }]) => ({
+            harness,
+            recordCount,
+            edgeCount,
+            share:
+                totalWeight > 0 ? (recordCount + edgeCount) / totalWeight : 0,
+        }),
+    );
+}

--- a/packages/doctor/tests/fixtures/accidental-sprawl/.github/copilot-instructions.md
+++ b/packages/doctor/tests/fixtures/accidental-sprawl/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+No references to Claude files — accidental sprawl.

--- a/packages/doctor/tests/fixtures/accidental-sprawl/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/accidental-sprawl/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+No cross-harness references here.

--- a/packages/doctor/tests/fixtures/canonical-contract/AGENTS.md
+++ b/packages/doctor/tests/fixtures/canonical-contract/AGENTS.md
@@ -1,0 +1,3 @@
+# Agents Instructions
+
+This repo uses a canonical AGENTS.md that all harnesses read. No harness-specific files.

--- a/packages/doctor/tests/fixtures/integration-scenario/.github/instructions/services.instructions.md
+++ b/packages/doctor/tests/fixtures/integration-scenario/.github/instructions/services.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "packages/services/**"
+---
+
+# Services Instructions
+
+Follow REST API conventions for service implementations.

--- a/packages/doctor/tests/fixtures/integration-scenario/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/integration-scenario/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Instructions
+
+This project uses both Claude Code and GitHub Copilot for AI assistance.
+
+We want Copilot to review our PRs automatically.

--- a/packages/doctor/tests/fixtures/intentional-hybrid/.github/copilot-instructions.md
+++ b/packages/doctor/tests/fixtures/intentional-hybrid/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+Global Copilot instructions for this intentional hybrid project.

--- a/packages/doctor/tests/fixtures/intentional-hybrid/.github/instructions/services.instructions.md
+++ b/packages/doctor/tests/fixtures/intentional-hybrid/.github/instructions/services.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "packages/services/**"
+---
+
+# Services Instructions
+
+Guidelines for service packages.

--- a/packages/doctor/tests/fixtures/intentional-hybrid/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/intentional-hybrid/CLAUDE.md
@@ -1,0 +1,9 @@
+---
+see: .github/instructions/services.instructions.md
+---
+
+# Project Instructions
+
+This Claude config references a Copilot instruction file, creating an intentional hybrid.
+
+@.github/instructions/services.instructions.md

--- a/packages/doctor/tests/fixtures/malformed-edge/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/malformed-edge/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Instructions
+
+This file has a hard-import to a nonexistent target.
+
+@./nonexistent-target.md

--- a/packages/doctor/tests/fixtures/path-traversal/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/path-traversal/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Instructions
+
+This file has a path-traversal reference.
+
+@../../../../outside-repo.md

--- a/packages/doctor/tests/fixtures/pure-claude/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/pure-claude/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+This is a pure Claude project with no cross-harness references.
+
+## Style Guide
+
+Use TypeScript with strict mode.

--- a/packages/doctor/tests/integration/full-pipeline.integration.test.ts
+++ b/packages/doctor/tests/integration/full-pipeline.integration.test.ts
@@ -1,0 +1,130 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { hasBlockingFindings } from "../../src/formatters/human-renderer.js";
+import { formatSummary } from "../../src/formatters/summary-formatter.js";
+import { scanRepository } from "../../src/gateways/scanner.js";
+import { classifyArchetype } from "../../src/use-cases/classify-archetype.js";
+import { CRITERIA } from "../../src/use-cases/criteria.js";
+import { evaluate } from "../../src/use-cases/evaluate-engine.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, "../fixtures");
+
+function fixture(name: string): string {
+    return resolve(fixturesDir, name);
+}
+
+describe("Full pipeline integration", () => {
+    describe("integration-scenario: Copilot desired but instructions missing", () => {
+        it("should detect copilot instructions file as missing", async () => {
+            const records = await scanRepository(
+                fixture("integration-scenario"),
+            );
+
+            const copilotRecord = records.find((r) => r.harness === "copilot");
+            expect(copilotRecord).toBeDefined();
+
+            const hasInstructions = records.some(
+                (r) =>
+                    r.harness === "copilot" &&
+                    r.path === ".github/copilot-instructions.md",
+            );
+            expect(hasInstructions).toBe(false);
+        });
+
+        it("should produce a critical missing-copilot-instructions finding", async () => {
+            const records = await scanRepository(
+                fixture("integration-scenario"),
+            );
+            const classification = classifyArchetype(records);
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification,
+                intent: null,
+            });
+
+            const criticalFinding = findings.find(
+                (f) => f.criterionId === "missing-copilot-instructions",
+            );
+            expect(criticalFinding).toBeDefined();
+            expect(criticalFinding?.severity).toBe("critical");
+            expect(criticalFinding?.classification).toBe("defect");
+        });
+
+        it("should have blocking findings that would cause non-zero exit", async () => {
+            const records = await scanRepository(
+                fixture("integration-scenario"),
+            );
+            const classification = classifyArchetype(records);
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification,
+                intent: null,
+            });
+
+            expect(hasBlockingFindings(findings)).toBe(true);
+        });
+
+        it("should classify as accidental-sprawl due to no cross-harness edges", async () => {
+            const records = await scanRepository(
+                fixture("integration-scenario"),
+            );
+            const classification = classifyArchetype(records);
+            expect(classification.archetype).toBe("accidental-sprawl");
+        });
+    });
+
+    describe("integration-scenario: summary output format", () => {
+        it("should produce a summary with correct archetype", async () => {
+            const records = await scanRepository(
+                fixture("integration-scenario"),
+            );
+            const classification = classifyArchetype(records);
+            const summary = formatSummary(records, classification);
+
+            expect(summary.archetype).toBe("accidental-sprawl");
+            expect(summary.totalRecords).toBeGreaterThan(0);
+            expect(summary.archetypeDescription).toBeTruthy();
+        });
+    });
+
+    describe("pure-claude: no intent, no copilot → only governance finding", () => {
+        it("should produce missing-intent-artifact but no critical findings", async () => {
+            const records = await scanRepository(fixture("pure-claude"));
+            const classification = classifyArchetype(records);
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification,
+                intent: null,
+            });
+
+            const critical = findings.filter(
+                (f) =>
+                    f.severity === "critical" && f.classification === "defect",
+            );
+            expect(critical).toHaveLength(0);
+
+            const intentFinding = findings.find(
+                (f) => f.criterionId === "missing-intent-artifact",
+            );
+            expect(intentFinding).toBeDefined();
+            expect(hasBlockingFindings(findings)).toBe(false);
+        });
+    });
+
+    describe("empty-repo: no records → no findings", () => {
+        it("should produce zero findings for an empty repo", async () => {
+            const records = await scanRepository(fixture("empty-repo"));
+            const classification = classifyArchetype(records);
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification,
+                intent: null,
+            });
+
+            expect(findings).toHaveLength(0);
+            expect(hasBlockingFindings(findings)).toBe(false);
+        });
+    });
+});

--- a/packages/doctor/tsconfig.json
+++ b/packages/doctor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/packages/doctor/vitest.config.ts
+++ b/packages/doctor/vitest.config.ts
@@ -1,0 +1,22 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+    test: {
+        globals: true,
+        exclude: [
+            "**/node_modules/**",
+            "**/dist/**",
+            "**/*.integration.test.ts",
+        ],
+    },
+    resolve: {
+        alias: {
+            "@lousy-agents/core": resolve(__dirname, "../core/src"),
+            "@lousy-agents/agentic-doctor": resolve(__dirname, "./src"),
+        },
+    },
+});

--- a/packages/mcp/src/tools/analyze-action-versions.ts
+++ b/packages/mcp/src/tools/analyze-action-versions.ts
@@ -2,9 +2,9 @@
  * MCP tool handler for analyzing GitHub Action versions across workflows.
  */
 
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import {
-    fileExists,
     listDirectoryWithinRoot,
     pathExistsWithinRoot,
     readTextWithinRoot,
@@ -78,7 +78,8 @@ export const analyzeActionVersionsHandler: ToolHandler = async (
 ) => {
     const dir = args.targetDir || process.cwd();
 
-    if (!(await fileExists(dir))) {
+    const dirStat = await stat(dir).catch(() => null);
+    if (dirStat === null || !dirStat.isDirectory()) {
         return errorResponse(`Target directory does not exist: ${dir}`);
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         alias: {
             "@lousy-agents/core": resolve(__dirname, "./packages/core/src"),
             "@lousy-agents/lint": resolve(__dirname, "./packages/lint/src"),
+            "@lousy-agents/agentic-doctor": resolve(
+                __dirname,
+                "./packages/doctor/src",
+            ),
         },
     },
 });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
         alias: {
             "@lousy-agents/core": resolve(__dirname, "./packages/core/src"),
             "@lousy-agents/lint": resolve(__dirname, "./packages/lint/src"),
+            "@lousy-agents/agentic-doctor": resolve(
+                __dirname,
+                "./packages/doctor/src",
+            ),
         },
     },
 });


### PR DESCRIPTION
## Summary

- Adds `packages/doctor` — a new `@lousy-agents/agentic-doctor` npm package that inventories agentic configuration across AI harnesses, classifies the repository archetype, evaluates capability preconditions, and reports findings
- Wires `doctor` as a subcommand in `packages/cli` via rspack alias and citty `subCommands`
- 67 unit + integration tests across all pipeline layers

## What's implemented

**Discovery layer** (`src/discover/`)
- `harness-footprints.ts` — footprint metadata for all 8 harnesses (claude, copilot, codex, antigravity, hermes, crush, pi, shared) with `primaryIndicators` for unambiguous file-to-harness assignment
- `edge-types.ts` — `HarnessName`, `InventoryRecord`, `Edge`, `EdgeDirection`, `EdgeType` types
- `scanner.ts` — safe repository walk using `listDirectoryWithinRoot`, harness detection via `matchesPrimaryIndicator`, edge resolution with path-traversal and missing-target detection
- `edge-parser.ts` — extracts hard-imports (`@path`), soft-references (frontmatter keys + markdown links), and glob-bindings (`applyTo`)

**Classify layer** (`src/classify/`)
- `profile.ts` — `buildHarnessProfiles()` with `PURE_DOMINANCE_THRESHOLD = 0.80`
- `archetype.ts` — six archetype rules: `pure`, `intentional-hybrid`, `canonical-contract`, `accidental-sprawl`, `none`, `ambiguous`

**Wisdom layer** (`src/wisdom/`)
- `client.ts` — typed `WisdomClient` with `WisdomUnavailableError` when submodule absent
- `evidence.ts` — `resolveEvidence()` extracts source passages for citation handles

**Criteria layer** (`src/criteria/`)
- `schema.ts` — `Criterion`, `CheckMethod`, `CheckMethodArgs`, `Severity`, `Classification` types
- `criteria.ts` — `CRITERIA` array: `missing-copilot-instructions` (critical), `missing-intent-artifact` (medium), malformed reference checks, and per-harness checks

**Elicit layer** (`src/elicit/`)
- `intent-artifact.ts` — Zod-validated `DeclaredIntentArtifact` read/write at `.agentic-doctor/intent.json`
- `ambiguity.ts` — detects finding-changing ambiguities for interactive Q&A

**Evaluate layer** (`src/evaluate/`)
- `engine.ts` — `evaluate()` maps `CheckMethod` handlers to `Finding[]`
- `findings.ts` — `Finding` type with `id: ${criterionId}:${targetId}` format

**Report/Summary layer** (`src/summary/`, `src/report/`)
- `formatter.ts` — archetype description strings, cross-harness edge count
- `renderer.ts` — severity-ordered human output; `hasBlockingFindings()` for exit-code logic
- `format.ts` — JSON serialization

**CLI** (`src/cli/index.ts`)
- `agentic-doctor [--summary] [--format human|json] [--ci]`
- Exit 1 when any `critical|high` defect finding present

**Test fixtures** (`tests/fixtures/`)
- `pure-claude`, `intentional-hybrid`, `accidental-sprawl`, `canonical-contract`, `malformed-edge`, `path-traversal`, `empty-repo`, `integration-scenario`

## Test plan

- [x] `npm test -- packages/doctor` — 67 tests pass across all layers
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npm run build --workspace=packages/doctor` — rspack compiled successfully
- [x] `npm run build --workspace=packages/cli` — rspack compiled with doctor command wired
- [x] `node packages/doctor/dist/cli/index.js --format json` — produces valid JSON with archetype classification on this repo
- [x] Pre-existing fuzz test failure in `packages/mcp` is unrelated to this PR (confirmed by running on main)

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeJLmpuBy9tthBtNuUAEzW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeJLmpuBy9tthBtNuUAEzW)_