### PR TITLE
fix(mcp): catch unhandled FsSafeError in analyzeActionVersionsHandler

### DIFF
--- a/packages/mcp/src/tools/analyze-action-versions.ts
+++ b/packages/mcp/src/tools/analyze-action-versions.ts
@@ -76,61 +76,70 @@ function buildUniqueActionsMap(
 export const analyzeActionVersionsHandler: ToolHandler = async (
     args: ToolArgs,
 ) => {
-    const dir = args.targetDir || process.cwd();
+    try {
+        const dir = args.targetDir || process.cwd();
 
-    if (!(await fileExists(dir))) {
-        return errorResponse(`Target directory does not exist: ${dir}`);
-    }
-
-    const workflowsRelativeDir = join(".github", "workflows");
-    if (!(await pathExistsWithinRoot(dir, workflowsRelativeDir))) {
-        return successResponse({
-            workflows: [],
-            uniqueActions: [],
-            message:
-                "No .github/workflows directory found - no workflows to analyze",
-        });
-    }
-
-    // Read all workflow files
-    const entries = await listDirectoryWithinRoot(dir, workflowsRelativeDir);
-    const files = entries
-        .filter((entry) => entry.isFile())
-        .map((entry) => entry.name);
-    const yamlFiles = files.filter(
-        (f) => f.endsWith(".yml") || f.endsWith(".yaml"),
-    );
-
-    const workflows: WorkflowActions[] = [];
-
-    for (const file of yamlFiles) {
-        const filePath = join(workflowsRelativeDir, file);
-        const actions = await parseWorkflowFile(dir, filePath);
-        if (actions && actions.length > 0) {
-            workflows.push({ file, actions });
+        if (!(await fileExists(dir))) {
+            return errorResponse(`Target directory does not exist: ${dir}`);
         }
+
+        const workflowsRelativeDir = join(".github", "workflows");
+        if (!(await pathExistsWithinRoot(dir, workflowsRelativeDir))) {
+            return successResponse({
+                workflows: [],
+                uniqueActions: [],
+                message:
+                    "No .github/workflows directory found - no workflows to analyze",
+            });
+        }
+
+        // Read all workflow files
+        const entries = await listDirectoryWithinRoot(
+            dir,
+            workflowsRelativeDir,
+        );
+        const files = entries
+            .filter((entry) => entry.isFile())
+            .map((entry) => entry.name);
+        const yamlFiles = files.filter(
+            (f) => f.endsWith(".yml") || f.endsWith(".yaml"),
+        );
+
+        const workflows: WorkflowActions[] = [];
+
+        for (const file of yamlFiles) {
+            const filePath = join(workflowsRelativeDir, file);
+            const actions = await parseWorkflowFile(dir, filePath);
+            if (actions && actions.length > 0) {
+                workflows.push({ file, actions });
+            }
+        }
+
+        // Build unique actions map
+        const actionVersionsMap = buildUniqueActionsMap(workflows);
+        const uniqueActions = Array.from(actionVersionsMap.entries()).map(
+            ([name, versions]) => ({
+                name,
+                versions: Array.from(versions),
+            }),
+        );
+
+        const totalActions = workflows.reduce(
+            (sum, w) => sum + w.actions.length,
+            0,
+        );
+
+        return successResponse({
+            workflows,
+            uniqueActions,
+            message:
+                workflows.length > 0
+                    ? `Found ${totalActions} action reference(s) across ${workflows.length} workflow(s), ${uniqueActions.length} unique action(s)`
+                    : "No action references found in workflows",
+        });
+    } catch (error) {
+        const message =
+            error instanceof Error ? error.message : "Unknown error occurred";
+        return errorResponse(`Failed to analyze action versions: ${message}`);
     }
-
-    // Build unique actions map
-    const actionVersionsMap = buildUniqueActionsMap(workflows);
-    const uniqueActions = Array.from(actionVersionsMap.entries()).map(
-        ([name, versions]) => ({
-            name,
-            versions: Array.from(versions),
-        }),
-    );
-
-    const totalActions = workflows.reduce(
-        (sum, w) => sum + w.actions.length,
-        0,
-    );
-
-    return successResponse({
-        workflows,
-        uniqueActions,
-        message:
-            workflows.length > 0
-                ? `Found ${totalActions} action reference(s) across ${workflows.length} workflow(s), ${uniqueActions.length} unique action(s)`
-                : "No action references found in workflows",
-    });
 };


### PR DESCRIPTION
## Summary

- `analyzeActionVersionsHandler` was missing the outer `try/catch` that every other handler has, causing `server.fuzz.test.ts` to fail non-deterministically
- When `targetDir` resolves to a file path (e.g. `../../../etc/passwd`), `fs-safe`'s `root()` requires a directory root and throws `FsSafeError("invalid-path")`, which `mapFsSafeError` re-throws as a regular `Error` — this error escaped the handler instead of being returned as an `errorResponse`
- The flakiness comes from `fast-check` using a random seed each run; the `"../../../etc/passwd"` constant in `adversarialTargetDirReadOnly` is only sometimes picked, so the test fails only on certain runs

## Root cause

`fileExists()` uses `fs.access()`, which returns `true` for any existing filesystem entry including regular files. So when `targetDir = "../../../etc/passwd"` (a file), `fileExists` returns `true` and execution falls through to `pathExistsWithinRoot`, which calls `fs-safe`'s `root()` on a non-directory path and throws.

## Fix

Wrap the handler body in the same top-level `try/catch` pattern used by all other handlers (`discoverEnvironmentHandler`, etc.), converting any uncaught error to an `errorResponse`.

## Test plan

- [ ] `server.fuzz.test.ts` passes consistently across multiple runs (verified locally: 3/3 runs passed all 28 tests)
- [ ] The specific counterexample `["../../../etc/passwd"]` now returns `{ success: false, error: "Failed to analyze action versions: ..." }` instead of throwing

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kaj6pzmNJM4Lin19j6irLj)_