### PR TITLE
fix(doctor): stop mislabeling copilot->claude markdown links as @import misuse

### DIFF
--- a/packages/doctor/src/entities/harness-footprints.test.ts
+++ b/packages/doctor/src/entities/harness-footprints.test.ts
@@ -108,6 +108,14 @@ describe("HARNESS_FOOTPRINTS", () => {
             );
         });
     });
+
+    describe("copilot harness root-only convention files", () => {
+        it("should document that Copilot also loads CLAUDE.md and GEMINI.md, but only from the repo root", () => {
+            expect(HARNESS_FOOTPRINTS.copilot.rootOnlyConventionFiles).toEqual(
+                expect.arrayContaining(["CLAUDE.md", "GEMINI.md"]),
+            );
+        });
+    });
 });
 
 describe("getFootprint", () => {

--- a/packages/doctor/src/entities/harness-footprints.ts
+++ b/packages/doctor/src/entities/harness-footprints.ts
@@ -15,6 +15,12 @@ export interface HarnessFootprint {
     walkBoundary: WalkBoundary;
     conventionFiles: readonly string[];
     conventionDirs: readonly string[];
+    /**
+     * Convention files this harness only loads when they sit at the
+     * repository root — unlike conventionFiles, these are not discovered
+     * via walkBoundary and are ignored anywhere else in the tree.
+     */
+    rootOnlyConventionFiles?: readonly string[];
     crossRefMechanisms: readonly CrossRefMechanism[];
     /**
      * Patterns used to detect whether a file belongs to this harness.
@@ -70,6 +76,7 @@ export const HARNESS_FOOTPRINTS: Readonly<
         walkBoundary: "project",
         conventionFiles: [".github/copilot-instructions.md"],
         conventionDirs: [".github/instructions/"],
+        rootOnlyConventionFiles: ["CLAUDE.md", "GEMINI.md"],
         primaryIndicators: [
             ".github/copilot-instructions.md",
             ".github/instructions/",

--- a/packages/doctor/src/use-cases/criteria.ts
+++ b/packages/doctor/src/use-cases/criteria.ts
@@ -64,7 +64,7 @@ export const CRITERIA: readonly Criterion[] = [
         classification: "advisory",
         category: "wrong-direction",
         description:
-            "A Copilot instruction file uses Claude's @import syntax to reference a Claude instruction file. Copilot does not process @import directives, so this reference has no effect and may indicate copy-paste drift.",
+            "A Copilot instruction file uses Claude's @path hard-import syntax to reference a Claude instruction file. Copilot does not process @path hard-imports, so this reference has no effect and may indicate copy-paste drift.",
         checkMethod: "inventory.edgeDirectionExists",
         checkArgs: {
             fromHarness: "copilot",

--- a/packages/doctor/src/use-cases/criteria.ts
+++ b/packages/doctor/src/use-cases/criteria.ts
@@ -64,11 +64,27 @@ export const CRITERIA: readonly Criterion[] = [
         classification: "advisory",
         category: "wrong-direction",
         description:
-            "A Copilot instruction file references a Claude instruction file. Copilot does not process @import directives, so this reference has no effect and may indicate copy-paste drift.",
+            "A Copilot instruction file uses Claude's @import syntax to reference a Claude instruction file. Copilot does not process @import directives, so this reference has no effect and may indicate copy-paste drift.",
         checkMethod: "inventory.edgeDirectionExists",
         checkArgs: {
             fromHarness: "copilot",
             toHarness: "claude",
+            edgeType: "hard-import",
+        },
+    },
+    {
+        id: "wrong-direction-copilot-links-claude",
+        appliesToHarness: "copilot",
+        severity: "medium",
+        classification: "advisory",
+        category: "wrong-direction",
+        description:
+            "A Copilot instruction file contains a markdown hyperlink (or frontmatter see:/references:/requires: entry) pointing to a Claude instruction file. The Copilot CLI does not follow markdown hyperlinks or soft references in instructions, so this reference has no effect and may indicate copy-paste drift.",
+        checkMethod: "inventory.edgeDirectionExists",
+        checkArgs: {
+            fromHarness: "copilot",
+            toHarness: "claude",
+            edgeType: "soft-reference",
         },
     },
     {

--- a/packages/doctor/src/use-cases/evaluate-engine.test.ts
+++ b/packages/doctor/src/use-cases/evaluate-engine.test.ts
@@ -315,7 +315,7 @@ describe("evaluate", () => {
     });
 
     describe("wrong-direction-copilot-imports-claude criterion (hard-import edges only)", () => {
-        it("should produce a finding mentioning @import directives when a copilot file has a hard-import edge to a claude file", () => {
+        it("should produce a finding mentioning @path hard-imports when a copilot file has a hard-import edge to a claude file", () => {
             const records: InventoryRecord[] = [
                 makeRecord({
                     harness: "copilot",
@@ -350,7 +350,7 @@ describe("evaluate", () => {
                     f.criterionId === "wrong-direction-copilot-imports-claude",
             );
             expect(finding).toBeDefined();
-            expect(finding?.description).toMatch(/@import/);
+            expect(finding?.description).toMatch(/@path/);
         });
 
         it("should not produce a wrong-direction-copilot-imports-claude finding when the only copilot->claude edge is a markdown hyperlink (soft-reference)", () => {
@@ -392,7 +392,7 @@ describe("evaluate", () => {
     });
 
     describe("wrong-direction-copilot-links-claude criterion (markdown hyperlink / soft-reference edges)", () => {
-        it("should produce a finding describing a markdown hyperlink, not @import directives, when a copilot file links to a claude file", () => {
+        it("should produce a finding describing a markdown hyperlink, not @path hard-imports, when a copilot file links to a claude file", () => {
             const records: InventoryRecord[] = [
                 makeRecord({
                     harness: "copilot",
@@ -426,7 +426,7 @@ describe("evaluate", () => {
                 (f) => f.criterionId === "wrong-direction-copilot-links-claude",
             );
             expect(finding).toBeDefined();
-            expect(finding?.description).not.toMatch(/@import/);
+            expect(finding?.description).not.toMatch(/@path/);
             expect(finding?.description.toLowerCase()).toMatch(
                 /markdown hyperlink/,
             );

--- a/packages/doctor/src/use-cases/evaluate-engine.test.ts
+++ b/packages/doctor/src/use-cases/evaluate-engine.test.ts
@@ -314,6 +314,151 @@ describe("evaluate", () => {
         });
     });
 
+    describe("wrong-direction-copilot-imports-claude criterion (hard-import edges only)", () => {
+        it("should produce a finding mentioning @import directives when a copilot file has a hard-import edge to a claude file", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [
+                        {
+                            type: "hard-import",
+                            direction: {
+                                from: ".github/copilot-instructions.md",
+                                to: "CLAUDE.md",
+                            },
+                            target: "CLAUDE.md",
+                            malformed: false,
+                        },
+                    ],
+                }),
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("accidental-sprawl"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) =>
+                    f.criterionId === "wrong-direction-copilot-imports-claude",
+            );
+            expect(finding).toBeDefined();
+            expect(finding?.description).toMatch(/@import/);
+        });
+
+        it("should not produce a wrong-direction-copilot-imports-claude finding when the only copilot->claude edge is a markdown hyperlink (soft-reference)", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [
+                        {
+                            type: "soft-reference",
+                            direction: {
+                                from: ".github/copilot-instructions.md",
+                                to: "CLAUDE.md",
+                            },
+                            target: "CLAUDE.md",
+                            malformed: false,
+                        },
+                    ],
+                }),
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("accidental-sprawl"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) =>
+                    f.criterionId === "wrong-direction-copilot-imports-claude",
+            );
+            expect(finding).toBeUndefined();
+        });
+    });
+
+    describe("wrong-direction-copilot-links-claude criterion (markdown hyperlink / soft-reference edges)", () => {
+        it("should produce a finding describing a markdown hyperlink, not @import directives, when a copilot file links to a claude file", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [
+                        {
+                            type: "soft-reference",
+                            direction: {
+                                from: ".github/copilot-instructions.md",
+                                to: "CLAUDE.md",
+                            },
+                            target: "CLAUDE.md",
+                            malformed: false,
+                        },
+                    ],
+                }),
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("accidental-sprawl"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "wrong-direction-copilot-links-claude",
+            );
+            expect(finding).toBeDefined();
+            expect(finding?.description).not.toMatch(/@import/);
+            expect(finding?.description.toLowerCase()).toMatch(
+                /markdown hyperlink/,
+            );
+        });
+
+        it("should not produce a wrong-direction-copilot-links-claude finding when copilot has no reference to a claude file", () => {
+            const records: InventoryRecord[] = [
+                makeRecord({
+                    harness: "copilot",
+                    path: ".github/copilot-instructions.md",
+                    id: "copilot:.github/copilot-instructions.md",
+                    edges: [],
+                }),
+                makeRecord({
+                    harness: "claude",
+                    path: "CLAUDE.md",
+                    id: "claude:CLAUDE.md",
+                }),
+            ];
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification: makeClassification("accidental-sprawl"),
+                intent: null,
+            });
+
+            const finding = findings.find(
+                (f) => f.criterionId === "wrong-direction-copilot-links-claude",
+            );
+            expect(finding).toBeUndefined();
+        });
+    });
+
     describe("finding id format", () => {
         it("should produce ids in ${criterionId}:${targetId} format", () => {
             const records: InventoryRecord[] = [

--- a/packages/doctor/tests/fixtures/copilot-markdown-link-to-claude/.github/copilot-instructions.md
+++ b/packages/doctor/tests/fixtures/copilot-markdown-link-to-claude/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot Instructions
+
+See the [Claude instructions](../CLAUDE.md) for shared conventions.

--- a/packages/doctor/tests/fixtures/copilot-markdown-link-to-claude/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/copilot-markdown-link-to-claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+Shared conventions referenced by Copilot via a markdown hyperlink (not an @import).

--- a/packages/doctor/tests/integration/full-pipeline.integration.test.ts
+++ b/packages/doctor/tests/integration/full-pipeline.integration.test.ts
@@ -113,6 +113,48 @@ describe("Full pipeline integration", () => {
         });
     });
 
+    describe("copilot-markdown-link-to-claude: copilot instructions link to a Claude file via markdown hyperlink", () => {
+        it("should record the reference as a soft-reference edge, not a hard-import", async () => {
+            const records = await scanRepository(
+                fixture("copilot-markdown-link-to-claude"),
+            );
+
+            const copilotRecord = records.find(
+                (r) => r.path === ".github/copilot-instructions.md",
+            );
+            expect(copilotRecord).toBeDefined();
+            expect(copilotRecord?.edges).toHaveLength(1);
+            expect(copilotRecord?.edges[0]?.type).toBe("soft-reference");
+        });
+
+        it("should produce a wrong-direction-copilot-links-claude finding describing a markdown hyperlink instead of @import directives", async () => {
+            const records = await scanRepository(
+                fixture("copilot-markdown-link-to-claude"),
+            );
+            const classification = classifyArchetype(records);
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification,
+                intent: null,
+            });
+
+            const linkFinding = findings.find(
+                (f) => f.criterionId === "wrong-direction-copilot-links-claude",
+            );
+            expect(linkFinding).toBeDefined();
+            expect(linkFinding?.description).not.toMatch(/@import/);
+            expect(linkFinding?.description.toLowerCase()).toMatch(
+                /markdown hyperlink/,
+            );
+
+            const misleadingFinding = findings.find(
+                (f) =>
+                    f.criterionId === "wrong-direction-copilot-imports-claude",
+            );
+            expect(misleadingFinding).toBeUndefined();
+        });
+    });
+
     describe("empty-repo: no records → no findings", () => {
         it("should produce zero findings for an empty repo", async () => {
             const records = await scanRepository(fixture("empty-repo"));

--- a/packages/doctor/tests/integration/full-pipeline.integration.test.ts
+++ b/packages/doctor/tests/integration/full-pipeline.integration.test.ts
@@ -127,7 +127,7 @@ describe("Full pipeline integration", () => {
             expect(copilotRecord?.edges[0]?.type).toBe("soft-reference");
         });
 
-        it("should produce a wrong-direction-copilot-links-claude finding describing a markdown hyperlink instead of @import directives", async () => {
+        it("should produce a wrong-direction-copilot-links-claude finding describing a markdown hyperlink instead of @path hard-imports", async () => {
             const records = await scanRepository(
                 fixture("copilot-markdown-link-to-claude"),
             );
@@ -142,7 +142,7 @@ describe("Full pipeline integration", () => {
                 (f) => f.criterionId === "wrong-direction-copilot-links-claude",
             );
             expect(linkFinding).toBeDefined();
-            expect(linkFinding?.description).not.toMatch(/@import/);
+            expect(linkFinding?.description).not.toMatch(/@path/);
             expect(linkFinding?.description.toLowerCase()).toMatch(
                 /markdown hyperlink/,
             );


### PR DESCRIPTION
## Summary

Fixes #903.

- The `wrong-direction-copilot-imports-claude` criterion fired for **any** edge from a Copilot instruction file to a Claude instruction file, regardless of how the reference was made. This meant a plain markdown hyperlink (e.g. `[see](../CLAUDE.md)`) inside `.github/copilot-instructions.md` produced a finding claiming "Copilot does not process `@import` directives" — which misdiagnoses the mechanism, since a markdown hyperlink is not Claude's `@import` syntax.
- Split the criterion by edge type: `wrong-direction-copilot-imports-claude` now only fires for actual `hard-import` (`@path/to/file`) edges, and a new `wrong-direction-copilot-links-claude` criterion covers `soft-reference` edges (markdown hyperlinks and frontmatter `see:`/`references:`/`requires:` entries) with accurate wording — the Copilot CLI doesn't follow markdown hyperlinks or soft references either, but for a different reason than `@import` processing.
- Documented in `harness-footprints.ts` that the Copilot CLI also natively loads `CLAUDE.md`/`GEMINI.md`, but **only when they sit at the repository root** — confirmed against GitHub's [custom instructions docs](https://docs.github.com/en/copilot/reference/custom-instructions-support) and by manual testing with the Copilot CLI's `/instructions` command (per the issue report).

## Test plan

- [x] Added failing unit tests in `evaluate-engine.test.ts` reproducing the mislabeled finding, confirmed they failed before the fix
- [x] Added a `copilot-markdown-link-to-claude` fixture + integration test in `full-pipeline.integration.test.ts` reproducing the bug end-to-end
- [x] Added a unit test in `harness-footprints.test.ts` for the root-only `CLAUDE.md`/`GEMINI.md` documentation gap
- [x] `npx vitest run` (unit) — all passing
- [x] `npx vitest run --config vitest.integration.config.ts` (integration, including CLI-level `doctor.integration.test.ts` against a built binary) — all passing
- [x] `npx biome check` — no new errors/warnings
- [x] `npm run lint:architecture` — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrrjP6hQmkMajK4zLezbNb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrrjP6hQmkMajK4zLezbNb)_