### PR TITLE
fix(doctor): detect symlinked instruction files during repo scan

### DIFF
--- a/packages/doctor/src/gateways/scanner.test.ts
+++ b/packages/doctor/src/gateways/scanner.test.ts
@@ -211,6 +211,27 @@ describe("scanRepository", () => {
         });
     });
 
+    describe("when scanning a repository with a symlink that escapes the repo root", () => {
+        it.skipIf(process.platform === "win32")(
+            "should have a symlink fixture at AGENTS.md pointing outside the repo root, so this test actually exercises the traversal guard",
+            async () => {
+                const stats = await lstat(
+                    resolve(fixture("symlinked-outside-root"), "AGENTS.md"),
+                );
+                expect(stats.isSymbolicLink()).toBe(true);
+            },
+        );
+
+        it("should not inventory a symlinked file whose resolved target lives outside the repo root", async () => {
+            const records = await scanRepository(
+                fixture("symlinked-outside-root"),
+            );
+
+            const agentsMd = records.find((r) => r.path === "AGENTS.md");
+            expect(agentsMd).toBeUndefined();
+        });
+    });
+
     describe("when scanning a repository with an empty-repo fixture", () => {
         it("should return an empty inventory", async () => {
             const records = await scanRepository(fixture("empty-repo"));

--- a/packages/doctor/src/gateways/scanner.test.ts
+++ b/packages/doctor/src/gateways/scanner.test.ts
@@ -1,3 +1,4 @@
+import { lstat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -183,6 +184,30 @@ describe("scanRepository", () => {
 
             const agentsMd = records.find((r) => r.path.endsWith("AGENTS.md"));
             expect(agentsMd?.id).toBe("shared:AGENTS.md");
+        });
+    });
+
+    describe("when scanning a repository with a symlinked instructions directory", () => {
+        it.skipIf(process.platform === "win32")(
+            "should have a symlink fixture at .claude, so this test actually exercises symlink handling",
+            async () => {
+                const stats = await lstat(
+                    resolve(fixture("symlinked-instructions-dir"), ".claude"),
+                );
+                expect(stats.isSymbolicLink()).toBe(true);
+            },
+        );
+
+        it("should discover a file nested inside the symlinked directory", async () => {
+            const records = await scanRepository(
+                fixture("symlinked-instructions-dir"),
+            );
+
+            const claudeMd = records.find(
+                (r) => r.path === ".claude/CLAUDE.md",
+            );
+            expect(claudeMd).toBeDefined();
+            expect(claudeMd?.harness).toBe("claude");
         });
     });
 

--- a/packages/doctor/src/gateways/scanner.ts
+++ b/packages/doctor/src/gateways/scanner.ts
@@ -2,7 +2,6 @@ import { realpath, stat } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import {
     listDirectoryWithinRoot,
-    readFileNoFollow,
     readTextWithinRoot,
 } from "@lousy-agents/core/gateways/file-system-utils.js";
 import type {
@@ -141,14 +140,14 @@ function resolveEdge(
 }
 
 /**
- * fs-safe's listing rejects symlinks outright, so a symlinked instruction
- * file (e.g. a repo-root AGENTS.md pointing at a canonical doc) is reported
- * as neither a file nor a directory and silently disappears from the scan.
- * Resolve the target ourselves and only follow it when it stays inside the
- * repo root, mirroring the traversal guard already used for edge targets.
- * Stats the already-resolved real path (rather than re-resolving the
- * symlink) so the within-root check and the type check observe the same
- * target, closing the TOCTOU window between the two.
+ * fs-safe's listing/reading rejects symlinks outright, so a symlinked
+ * instruction file or directory (e.g. a repo-root AGENTS.md pointing at a
+ * canonical doc) is reported as neither a file nor a directory and silently
+ * disappears from the scan. Resolve the target ourselves and only follow it
+ * when it stays inside the repo root, mirroring the traversal guard already
+ * used for edge targets. Stats the already-resolved real path (rather than
+ * re-resolving the symlink) so the within-root check and the type check
+ * observe the same target, closing the TOCTOU window between the two.
  */
 async function resolveSymlink(
     rootReal: string,
@@ -169,22 +168,38 @@ async function resolveSymlink(
     }
 }
 
+interface CollectedFile {
+    absPath: string;
+    relPath: string;
+    readRoot: string;
+    readRelPath: string;
+}
+
+/**
+ * Walks the repo tree, tracking two coordinate systems in parallel:
+ *  - (listRoot, listRelDir): where fs-safe should actually list/read from.
+ *    This starts at topRepoRoot but re-roots to rootReal + a real relative
+ *    path once the walk crosses a symlinked directory, since fs-safe cannot
+ *    list a path that is itself a symlink.
+ *  - logicalPrefix: the repo-root-relative path as it appears in the tree,
+ *    used for InventoryRecord.path/absPath so a file's identity reflects
+ *    where it's *referenced from*, not where the symlink target physically
+ *    lives.
+ */
 async function collectFiles(
-    repoRoot: string,
+    listRoot: string,
+    listRelDir: string,
+    logicalPrefix: string,
+    topRepoRoot: string,
     rootReal: string,
-    relDir: string,
-    collected: Array<{
-        absPath: string;
-        relPath: string;
-        realAbsPath: string | null;
-    }>,
+    collected: CollectedFile[],
     depth = 0,
 ): Promise<void> {
     if (depth > 10) return;
 
     let entries: Awaited<ReturnType<typeof listDirectoryWithinRoot>>;
     try {
-        entries = await listDirectoryWithinRoot(repoRoot, relDir);
+        entries = await listDirectoryWithinRoot(listRoot, listRelDir);
     } catch {
         return;
     }
@@ -192,13 +207,18 @@ async function collectFiles(
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
-        const entryRel = relDir ? `${relDir}/${entry.name}` : entry.name;
-        const entryAbs = resolve(repoRoot, entryRel);
+        const listEntryRel = listRelDir
+            ? `${listRelDir}/${entry.name}`
+            : entry.name;
+        const logicalRel = logicalPrefix
+            ? `${logicalPrefix}/${entry.name}`
+            : entry.name;
+        const listEntryAbs = resolve(listRoot, listEntryRel);
 
         const isDirectory = entry.isDirectory();
         const isFile = entry.isFile();
         const symlink = entry.isSymbolicLink()
-            ? await resolveSymlink(rootReal, entryAbs)
+            ? await resolveSymlink(rootReal, listEntryAbs)
             : null;
 
         if (isDirectory || symlink?.kind === "directory") {
@@ -209,21 +229,43 @@ async function collectFiles(
             ) {
                 continue;
             }
-            await collectFiles(
-                repoRoot,
-                rootReal,
-                entryRel,
-                collected,
-                depth + 1,
-            );
+            if (symlink?.kind === "directory") {
+                // Re-root the walk at rootReal so the symlinked directory
+                // (and anything beneath it) is listed via its real,
+                // symlink-free path — fs-safe rejects listing a path that
+                // is itself a symlink.
+                await collectFiles(
+                    rootReal,
+                    relative(rootReal, symlink.real),
+                    logicalRel,
+                    topRepoRoot,
+                    rootReal,
+                    collected,
+                    depth + 1,
+                );
+            } else {
+                await collectFiles(
+                    listRoot,
+                    listEntryRel,
+                    logicalRel,
+                    topRepoRoot,
+                    rootReal,
+                    collected,
+                    depth + 1,
+                );
+            }
         } else if (
             (isFile || symlink?.kind === "file") &&
             isScannableFile(entry.name)
         ) {
             collected.push({
-                absPath: entryAbs,
-                relPath: entryRel,
-                realAbsPath: symlink?.kind === "file" ? symlink.real : null,
+                absPath: resolve(topRepoRoot, logicalRel),
+                relPath: logicalRel,
+                readRoot: symlink?.kind === "file" ? rootReal : listRoot,
+                readRelPath:
+                    symlink?.kind === "file"
+                        ? relative(rootReal, symlink.real)
+                        : listEntryRel,
             });
         }
     }
@@ -235,12 +277,8 @@ export async function scanRepository(
     const absRoot = resolve(repoRoot);
     const rootReal = await realpath(absRoot);
 
-    const allFiles: Array<{
-        absPath: string;
-        relPath: string;
-        realAbsPath: string | null;
-    }> = [];
-    await collectFiles(absRoot, rootReal, "", allFiles);
+    const allFiles: CollectedFile[] = [];
+    await collectFiles(absRoot, "", "", absRoot, rootReal, allFiles);
 
     const existingAbsPaths = new Set(allFiles.map((f) => f.absPath));
 
@@ -251,21 +289,18 @@ export async function scanRepository(
         content: string | null;
     }> = [];
 
-    for (const { absPath, relPath, realAbsPath } of allFiles) {
+    for (const { absPath, relPath, readRoot, readRelPath } of allFiles) {
         const harness = determineHarness(relPath);
         if (harness === null) continue;
 
         let content: string | null = null;
         if (isMarkdownFile(relPath)) {
             try {
-                content =
-                    realAbsPath !== null
-                        ? await readFileNoFollow(realAbsPath, MAX_FILE_BYTES)
-                        : await readTextWithinRoot(
-                              absRoot,
-                              relPath,
-                              MAX_FILE_BYTES,
-                          );
+                content = await readTextWithinRoot(
+                    readRoot,
+                    readRelPath,
+                    MAX_FILE_BYTES,
+                );
             } catch {
                 content = null;
             }

--- a/packages/doctor/src/gateways/scanner.ts
+++ b/packages/doctor/src/gateways/scanner.ts
@@ -2,6 +2,7 @@ import { realpath, stat } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import {
     listDirectoryWithinRoot,
+    readFileNoFollow,
     readTextWithinRoot,
 } from "@lousy-agents/core/gateways/file-system-utils.js";
 import type {
@@ -145,20 +146,23 @@ function resolveEdge(
  * as neither a file nor a directory and silently disappears from the scan.
  * Resolve the target ourselves and only follow it when it stays inside the
  * repo root, mirroring the traversal guard already used for edge targets.
+ * Stats the already-resolved real path (rather than re-resolving the
+ * symlink) so the within-root check and the type check observe the same
+ * target, closing the TOCTOU window between the two.
  */
-async function resolveSymlinkKind(
+async function resolveSymlink(
     rootReal: string,
     entryAbs: string,
-): Promise<"file" | "directory" | null> {
+): Promise<{ kind: "file" | "directory"; real: string } | null> {
     try {
         const real = await realpath(entryAbs);
         const isWithinRoot =
             real === rootReal || real.startsWith(`${rootReal}${sep}`);
         if (!isWithinRoot) return null;
 
-        const targetStat = await stat(entryAbs);
-        if (targetStat.isDirectory()) return "directory";
-        if (targetStat.isFile()) return "file";
+        const targetStat = await stat(real);
+        if (targetStat.isDirectory()) return { kind: "directory", real };
+        if (targetStat.isFile()) return { kind: "file", real };
         return null;
     } catch {
         return null;
@@ -169,7 +173,11 @@ async function collectFiles(
     repoRoot: string,
     rootReal: string,
     relDir: string,
-    collected: Array<{ absPath: string; relPath: string }>,
+    collected: Array<{
+        absPath: string;
+        relPath: string;
+        realAbsPath: string | null;
+    }>,
     depth = 0,
 ): Promise<void> {
     if (depth > 10) return;
@@ -189,11 +197,11 @@ async function collectFiles(
 
         const isDirectory = entry.isDirectory();
         const isFile = entry.isFile();
-        const symlinkKind = entry.isSymbolicLink()
-            ? await resolveSymlinkKind(rootReal, entryAbs)
+        const symlink = entry.isSymbolicLink()
+            ? await resolveSymlink(rootReal, entryAbs)
             : null;
 
-        if (isDirectory || symlinkKind === "directory") {
+        if (isDirectory || symlink?.kind === "directory") {
             if (
                 entry.name === "node_modules" ||
                 entry.name === ".git" ||
@@ -209,10 +217,14 @@ async function collectFiles(
                 depth + 1,
             );
         } else if (
-            (isFile || symlinkKind === "file") &&
+            (isFile || symlink?.kind === "file") &&
             isScannableFile(entry.name)
         ) {
-            collected.push({ absPath: entryAbs, relPath: entryRel });
+            collected.push({
+                absPath: entryAbs,
+                relPath: entryRel,
+                realAbsPath: symlink?.kind === "file" ? symlink.real : null,
+            });
         }
     }
 }
@@ -223,7 +235,11 @@ export async function scanRepository(
     const absRoot = resolve(repoRoot);
     const rootReal = await realpath(absRoot);
 
-    const allFiles: Array<{ absPath: string; relPath: string }> = [];
+    const allFiles: Array<{
+        absPath: string;
+        relPath: string;
+        realAbsPath: string | null;
+    }> = [];
     await collectFiles(absRoot, rootReal, "", allFiles);
 
     const existingAbsPaths = new Set(allFiles.map((f) => f.absPath));
@@ -235,18 +251,21 @@ export async function scanRepository(
         content: string | null;
     }> = [];
 
-    for (const { absPath, relPath } of allFiles) {
+    for (const { absPath, relPath, realAbsPath } of allFiles) {
         const harness = determineHarness(relPath);
         if (harness === null) continue;
 
         let content: string | null = null;
         if (isMarkdownFile(relPath)) {
             try {
-                content = await readTextWithinRoot(
-                    absRoot,
-                    relPath,
-                    MAX_FILE_BYTES,
-                );
+                content =
+                    realAbsPath !== null
+                        ? await readFileNoFollow(realAbsPath, MAX_FILE_BYTES)
+                        : await readTextWithinRoot(
+                              absRoot,
+                              relPath,
+                              MAX_FILE_BYTES,
+                          );
             } catch {
                 content = null;
             }

--- a/packages/doctor/src/gateways/scanner.ts
+++ b/packages/doctor/src/gateways/scanner.ts
@@ -1,3 +1,4 @@
+import { realpath, stat } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 import {
     listDirectoryWithinRoot,
@@ -138,8 +139,35 @@ function resolveEdge(
     };
 }
 
+/**
+ * fs-safe's listing rejects symlinks outright, so a symlinked instruction
+ * file (e.g. a repo-root AGENTS.md pointing at a canonical doc) is reported
+ * as neither a file nor a directory and silently disappears from the scan.
+ * Resolve the target ourselves and only follow it when it stays inside the
+ * repo root, mirroring the traversal guard already used for edge targets.
+ */
+async function resolveSymlinkKind(
+    rootReal: string,
+    entryAbs: string,
+): Promise<"file" | "directory" | null> {
+    try {
+        const real = await realpath(entryAbs);
+        const isWithinRoot =
+            real === rootReal || real.startsWith(`${rootReal}${sep}`);
+        if (!isWithinRoot) return null;
+
+        const targetStat = await stat(entryAbs);
+        if (targetStat.isDirectory()) return "directory";
+        if (targetStat.isFile()) return "file";
+        return null;
+    } catch {
+        return null;
+    }
+}
+
 async function collectFiles(
     repoRoot: string,
+    rootReal: string,
     relDir: string,
     collected: Array<{ absPath: string; relPath: string }>,
     depth = 0,
@@ -159,7 +187,13 @@ async function collectFiles(
         const entryRel = relDir ? `${relDir}/${entry.name}` : entry.name;
         const entryAbs = resolve(repoRoot, entryRel);
 
-        if (entry.isDirectory()) {
+        const isDirectory = entry.isDirectory();
+        const isFile = entry.isFile();
+        const symlinkKind = entry.isSymbolicLink()
+            ? await resolveSymlinkKind(rootReal, entryAbs)
+            : null;
+
+        if (isDirectory || symlinkKind === "directory") {
             if (
                 entry.name === "node_modules" ||
                 entry.name === ".git" ||
@@ -167,8 +201,17 @@ async function collectFiles(
             ) {
                 continue;
             }
-            await collectFiles(repoRoot, entryRel, collected, depth + 1);
-        } else if (entry.isFile() && isScannableFile(entry.name)) {
+            await collectFiles(
+                repoRoot,
+                rootReal,
+                entryRel,
+                collected,
+                depth + 1,
+            );
+        } else if (
+            (isFile || symlinkKind === "file") &&
+            isScannableFile(entry.name)
+        ) {
             collected.push({ absPath: entryAbs, relPath: entryRel });
         }
     }
@@ -178,9 +221,10 @@ export async function scanRepository(
     repoRoot: string,
 ): Promise<InventoryRecord[]> {
     const absRoot = resolve(repoRoot);
+    const rootReal = await realpath(absRoot);
 
     const allFiles: Array<{ absPath: string; relPath: string }> = [];
-    await collectFiles(absRoot, "", allFiles);
+    await collectFiles(absRoot, rootReal, "", allFiles);
 
     const existingAbsPaths = new Set(allFiles.map((f) => f.absPath));
 

--- a/packages/doctor/tests/fixtures/symlinked-agents-md/.agents/skills/example.md
+++ b/packages/doctor/tests/fixtures/symlinked-agents-md/.agents/skills/example.md
@@ -1,0 +1,1 @@
+# Example skill

--- a/packages/doctor/tests/fixtures/symlinked-agents-md/AGENTS.md
+++ b/packages/doctor/tests/fixtures/symlinked-agents-md/AGENTS.md
@@ -1,0 +1,1 @@
+AGENTS.source.md

--- a/packages/doctor/tests/fixtures/symlinked-agents-md/AGENTS.source.md
+++ b/packages/doctor/tests/fixtures/symlinked-agents-md/AGENTS.source.md
@@ -1,3 +1,3 @@
 # Root agents file
 
-Real instructions live here.
+Real instructions live here. See the [example skill](.agents/skills/example.md) for conventions.

--- a/packages/doctor/tests/fixtures/symlinked-agents-md/AGENTS.source.md
+++ b/packages/doctor/tests/fixtures/symlinked-agents-md/AGENTS.source.md
@@ -1,0 +1,3 @@
+# Root agents file
+
+Real instructions live here.

--- a/packages/doctor/tests/fixtures/symlinked-instructions-dir/.claude
+++ b/packages/doctor/tests/fixtures/symlinked-instructions-dir/.claude
@@ -1,0 +1,1 @@
+real-claude

--- a/packages/doctor/tests/fixtures/symlinked-instructions-dir/real-claude/CLAUDE.md
+++ b/packages/doctor/tests/fixtures/symlinked-instructions-dir/real-claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# Real Claude instructions
+
+Live under a symlinked directory.

--- a/packages/doctor/tests/fixtures/symlinked-outside-root/AGENTS.md
+++ b/packages/doctor/tests/fixtures/symlinked-outside-root/AGENTS.md
@@ -1,0 +1,1 @@
+../pure-claude/CLAUDE.md

--- a/packages/doctor/tests/integration/full-pipeline.integration.test.ts
+++ b/packages/doctor/tests/integration/full-pipeline.integration.test.ts
@@ -1,3 +1,4 @@
+import { lstat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -156,6 +157,16 @@ describe("Full pipeline integration", () => {
     });
 
     describe("symlinked-agents-md: root AGENTS.md is a symlink to a real file", () => {
+        it.skipIf(process.platform === "win32")(
+            "should have a symlink fixture at AGENTS.md, so this test actually exercises symlink handling",
+            async () => {
+                const stats = await lstat(
+                    resolve(fixture("symlinked-agents-md"), "AGENTS.md"),
+                );
+                expect(stats.isSymbolicLink()).toBe(true);
+            },
+        );
+
         it("should discover the symlinked AGENTS.md as an inventory record", async () => {
             const records = await scanRepository(
                 fixture("symlinked-agents-md"),
@@ -163,6 +174,19 @@ describe("Full pipeline integration", () => {
 
             const agentsMd = records.find((r) => r.path === "AGENTS.md");
             expect(agentsMd).toBeDefined();
+        });
+
+        it("should read the symlink target's content and parse its edges, not treat it as empty", async () => {
+            const records = await scanRepository(
+                fixture("symlinked-agents-md"),
+            );
+
+            const agentsMd = records.find((r) => r.path === "AGENTS.md");
+            const softReference = agentsMd?.edges.find(
+                (e) => e.type === "soft-reference",
+            );
+            expect(softReference).toBeDefined();
+            expect(softReference?.malformed).toBe(false);
         });
 
         it("should not produce a missing-agents-md finding for codex", async () => {

--- a/packages/doctor/tests/integration/full-pipeline.integration.test.ts
+++ b/packages/doctor/tests/integration/full-pipeline.integration.test.ts
@@ -155,6 +155,34 @@ describe("Full pipeline integration", () => {
         });
     });
 
+    describe("symlinked-agents-md: root AGENTS.md is a symlink to a real file", () => {
+        it("should discover the symlinked AGENTS.md as an inventory record", async () => {
+            const records = await scanRepository(
+                fixture("symlinked-agents-md"),
+            );
+
+            const agentsMd = records.find((r) => r.path === "AGENTS.md");
+            expect(agentsMd).toBeDefined();
+        });
+
+        it("should not produce a missing-agents-md finding for codex", async () => {
+            const records = await scanRepository(
+                fixture("symlinked-agents-md"),
+            );
+            const classification = classifyArchetype(records);
+            const findings = evaluate(CRITERIA, {
+                records,
+                classification,
+                intent: null,
+            });
+
+            const missingAgentsMdFinding = findings.find(
+                (f) => f.criterionId === "missing-agents-md",
+            );
+            expect(missingAgentsMdFinding).toBeUndefined();
+        });
+    });
+
     describe("empty-repo: no records → no findings", () => {
         it("should produce zero findings for an empty repo", async () => {
             const records = await scanRepository(fixture("empty-repo"));


### PR DESCRIPTION
## Summary

Fixes #908 — `doctor` reported `missing-agents-md:codex:all` even though a root `AGENTS.md` existed.

**Root cause:** `scanRepository`'s directory walker (`packages/doctor/src/gateways/scanner.ts`) uses `@openclaw/fs-safe` for directory listings, which classifies symlinked entries as neither a file nor a directory (its `symlinks: "reject"` policy). `collectFiles` only checked `entry.isDirectory()` / `entry.isFile()`, so any symlinked instruction file — e.g. a repo-root `AGENTS.md` symlinked to a canonical doc, a pattern several teams use to keep Claude/Codex instructions in sync — was silently dropped from the inventory before `evaluate()` ever ran. Since the `missing-agents-md` criterion is gated on the presence of *any* `codex`-harness record (e.g. `.agents/skills/`, `.codex/`), a repo with both a symlinked root `AGENTS.md` and unrelated codex indicator files ended up with the criterion firing a false positive.

I reproduced this with a 20k-file synthetic tree matching the issue's description (large "output"/"fixtures" trees) first — that scenario turned out to behave correctly, since `determineHarness` matches on exact repo-relative paths, so nested `AGENTS.md` copies never interfere with the root-level check. The actual trigger was isolated to symlink handling, confirmed with a minimal repro and captured as a permanent regression test.

**Fix:** `collectFiles` now resolves symlink entries itself (`fs.realpath` + `fs.stat`), following them only when the resolved target stays within the repo root, and treats them as the file/directory they point to — otherwise it falls back to the prior behavior.

## Test plan

- Added `packages/doctor/tests/fixtures/symlinked-agents-md/` — a fixture with a root `AGENTS.md` symlink pointing at `AGENTS.source.md`, plus `.agents/skills/` to trigger the `codex` harness (mirroring the issue's precondition).
- Added two integration tests in `full-pipeline.integration.test.ts` that:
  - assert `scanRepository` discovers the symlinked `AGENTS.md` as an inventory record (fails without the fix)
  - assert `evaluate()` no longer produces a `missing-agents-md` finding for this repo (fails without the fix, reproducing the exact reported symptom)
- `npx vitest run packages/doctor` — 101 tests pass
- `npx vitest run --config vitest.integration.config.ts` — passes (one unrelated pre-existing failure: a testcontainers-based test that requires a Docker runtime unavailable in this sandbox)
- `npm test` — 1818 tests pass
- `npx biome check .` — no errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012eNAtkZHKyDp7D5hm54Fvm)_