### PR TITLE
feat(lint): Claude @ import expander and EffectiveDocument model

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -44,38 +44,38 @@ version = "0.87.0"
 backend = "npm:@devcontainers/cli"
 
 [[tools."github:lousy-agents/coach"]]
-version = "0.2.1"
+version = "0.3.0"
 backend = "github:lousy-agents/coach"
 
 [tools."github:lousy-agents/coach"."platforms.linux-x64"]
-checksum = "sha256:30c9aa4f2bce92219e81de7b4c6d885b1d3a1c2b0b0f9f424e030dca49ff7956"
-url = "https://github.com/lousy-agents/coach/releases/download/v0.2.1/coach_linux_x86_64.tar.gz"
-url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/492263419"
+checksum = "sha256:b5d3cce9c23cab6b249e26a765db70e3e08700664479e25924248ac72a91bdf9"
+url = "https://github.com/lousy-agents/coach/releases/download/v0.3.0/coach_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/507108794"
 provenance = "github-attestations"
 
 [tools."github:lousy-agents/coach"."platforms.linux-x64-musl"]
-checksum = "sha256:30c9aa4f2bce92219e81de7b4c6d885b1d3a1c2b0b0f9f424e030dca49ff7956"
-url = "https://github.com/lousy-agents/coach/releases/download/v0.2.1/coach_linux_x86_64.tar.gz"
-url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/492263419"
+checksum = "sha256:b5d3cce9c23cab6b249e26a765db70e3e08700664479e25924248ac72a91bdf9"
+url = "https://github.com/lousy-agents/coach/releases/download/v0.3.0/coach_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/507108794"
 provenance = "github-attestations"
 
 [tools."github:lousy-agents/coach"."platforms.macos-arm64"]
-checksum = "sha256:d3dc76eb554f7e3b167ef718ea42121c7fa5f88e92bfc8a905c4c7fecd5096f3"
-url = "https://github.com/lousy-agents/coach/releases/download/v0.2.1/coach_darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/492263417"
+checksum = "sha256:4dba7248858f3183fd06cc04396e0336a79010b20f6de50ffd68644e31f21755"
+url = "https://github.com/lousy-agents/coach/releases/download/v0.3.0/coach_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/507108795"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:lousy-agents/coach"."platforms.macos-x64"]
-checksum = "sha256:6dc61d9ea102779423f9685cbc6b45693ae0cc892d775a132af1c574d1597853"
-url = "https://github.com/lousy-agents/coach/releases/download/v0.2.1/coach_darwin_x86_64.tar.gz"
-url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/492263420"
+checksum = "sha256:ad61f4d0069f5b49f1d310204ade7daaaf4d70e6128c91ede216f9764a086f87"
+url = "https://github.com/lousy-agents/coach/releases/download/v0.3.0/coach_darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/507108797"
 provenance = "github-attestations"
 
 [tools."github:lousy-agents/coach"."platforms.windows-x64"]
-checksum = "sha256:b0af7e48551198d8cc421d06a57e6553c038a42b83892c35ea60ec1eab6f622c"
-url = "https://github.com/lousy-agents/coach/releases/download/v0.2.1/coach_windows_x86_64.zip"
-url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/492263421"
+checksum = "sha256:595fb22e7ec0dcba1932c41ff597855bc678d26d3dbdf57f5c8fc0e5215890ae"
+url = "https://github.com/lousy-agents/coach/releases/download/v0.3.0/coach_windows_x86_64.zip"
+url_api = "https://api.github.com/repos/lousy-agents/coach/releases/assets/507108796"
 provenance = "github-attestations"
 
 [[tools.jq]]

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,7 @@ yamllint = "1.38.0"                # Created with `mise use --pin yamllint`
 "pipx:semgrep" = "1.163.0"
 devcontainer-cli = "0.87.0"
 "pipx:graphifyy" = "0.8.27"
-"github:lousy-agents/coach" = "0.2.1"
+"github:lousy-agents/coach" = "0.3.0"
 
 [tasks.coach-baseline]
 description = "Run coach codesignal baseline scan (all tracked files at HEAD)"

--- a/packages/core/src/lib/instruction-import-expand.test.ts
+++ b/packages/core/src/lib/instruction-import-expand.test.ts
@@ -356,4 +356,101 @@ describe("buildEffectiveDocument", () => {
             expect(result.content).not.toContain("SHOULD-NOT-APPEAR");
         });
     });
+
+    describe("given expansion graph and emit limits", () => {
+        it("should reject the edge at the exact maxEdges limit", async () => {
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@./a.md\n@./b.md\n");
+            await writeFile(join(repoRoot, "a.md"), "A\n");
+            await writeFile(join(repoRoot, "b.md"), "B\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+                limits: { maxEdges: 1 },
+            });
+
+            expect(
+                result.edges.filter((edge) => edge.status === "resolved"),
+            ).toHaveLength(1);
+            expect(
+                result.edges.some((edge) => edge.status === "size-exceeded"),
+            ).toBe(true);
+            expect(result.content).toContain("A\n");
+            expect(result.content).toContain("@./b.md");
+            expect(result.content).not.toContain("B\n");
+            expect(
+                result.expansionDiagnostics.some(
+                    (diagnostic) =>
+                        diagnostic.ruleId ===
+                        "instruction/import-size-exceeded",
+                ),
+            ).toBe(true);
+        });
+
+        it("should reject a new unique file at the exact maxUniqueFiles limit", async () => {
+            // Root counts as the first unique file; maxUniqueFiles=1 blocks any import target.
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@./extra.md\n");
+            await writeFile(join(repoRoot, "extra.md"), "EXTRA\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+                limits: { maxUniqueFiles: 1 },
+            });
+
+            expect(result.edges[0]?.status).toBe("size-exceeded");
+            expect(result.content).toBe("@./extra.md\n");
+            expect(result.content).not.toContain("EXTRA");
+            expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                "instruction/import-size-exceeded",
+            );
+        });
+
+        it("should stop expansion when a later literal would exceed the emit budget", async () => {
+            // Root emits "X\n" (2) then expands body (4) then trailing "TAIL\n" (5).
+            // Budget 6 allows "X\n" + "ABCD" exactly; trailing literal is clipped.
+            await writeFile(
+                join(repoRoot, "CLAUDE.md"),
+                "X\n@./body.md\nTAIL\n",
+            );
+            await writeFile(join(repoRoot, "body.md"), "ABCD");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+                limits: { maxEmittedBytes: 6 },
+            });
+
+            expect(result.content).toBe("X\nABCD");
+            expect(result.content).not.toContain("TAIL");
+            expect(result.edges[0]?.status).toBe("resolved");
+        });
+
+        it("should leave a token unexpanded when the emit budget is already exhausted", async () => {
+            // Prefix alone consumes the entire budget before the import token.
+            // Correct full-fit (`text.length <= room`) still enters expandToken,
+            // which records the resolved target path on the failed edge after read.
+            // Weakening full-fit to `<` aborts before expandToken and omits target.
+            await writeFile(
+                join(repoRoot, "CLAUDE.md"),
+                "PREFIX\n@./body.md\n",
+            );
+            await writeFile(join(repoRoot, "body.md"), "BODY\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+                limits: { maxEmittedBytes: "PREFIX\n".length },
+            });
+
+            expect(result.content.startsWith("PREFIX\n")).toBe(true);
+            expect(result.content).not.toContain("BODY");
+            const exceeded = result.edges.find(
+                (edge) => edge.status === "size-exceeded",
+            );
+            expect(exceeded).toBeDefined();
+            expect(exceeded?.target).toBe("body.md");
+            expect(exceeded?.rawTarget).toBe("./body.md");
+        });
+    });
 });

--- a/packages/core/src/lib/instruction-import-expand.test.ts
+++ b/packages/core/src/lib/instruction-import-expand.test.ts
@@ -1,0 +1,359 @@
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Chance from "chance";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    buildEffectiveDocument,
+    DEFAULT_MAX_EMITTED_BYTES,
+    DEFAULT_MAX_IMPORT_DEPTH,
+    DEFAULT_MAX_UNIQUE_FILES,
+} from "./instruction-import-expand.js";
+
+const chance = new Chance();
+
+describe("buildEffectiveDocument", () => {
+    let repoRoot: string;
+
+    beforeEach(async () => {
+        repoRoot = join(
+            tmpdir(),
+            `instruction-import-expand-${chance.hash({ length: 8 })}`,
+        );
+        await mkdir(repoRoot, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(repoRoot, { recursive: true, force: true });
+    });
+
+    describe("given a single valid relative import", () => {
+        it("should splice the imported body at the token position", async () => {
+            const rootBody = "before\n@./AGENTS.md\nafter\n";
+            const importedBody = "# Agents\nDo the thing.\n";
+            await writeFile(join(repoRoot, "CLAUDE.md"), rootBody);
+            await writeFile(join(repoRoot, "AGENTS.md"), importedBody);
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe(
+                "before\n# Agents\nDo the thing.\n\nafter\n",
+            );
+            expect(result.root).toBe("CLAUDE.md");
+            expect(result.edges).toHaveLength(1);
+            expect(result.edges[0]?.status).toBe("resolved");
+            expect(result.edges[0]?.target).toBe("AGENTS.md");
+            expect(result.expansionDiagnostics).toHaveLength(0);
+            expect(result.orderedSegments.length).toBeGreaterThanOrEqual(2);
+            expect(
+                result.orderedSegments.some(
+                    (segment) => segment.sourcePath === "AGENTS.md",
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe("given nested imports within the depth limit", () => {
+        it("should expand four hops and reject a fifth hop", async () => {
+            await writeFile(join(repoRoot, "f0.md"), "@./f1.md\n");
+            await writeFile(join(repoRoot, "f1.md"), "@./f2.md\n");
+            await writeFile(join(repoRoot, "f2.md"), "@./f3.md\n");
+            await writeFile(join(repoRoot, "f3.md"), "@./f4.md\n");
+            await writeFile(join(repoRoot, "f4.md"), "leaf-ok\n@./f5.md\n");
+            await writeFile(join(repoRoot, "f5.md"), "too-deep\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "f0.md",
+                limits: { maxDepth: DEFAULT_MAX_IMPORT_DEPTH },
+            });
+
+            expect(result.content).toContain("leaf-ok\n");
+            expect(result.content).toContain("@./f5.md");
+            expect(result.content).not.toContain("too-deep");
+            expect(
+                result.edges.some((edge) => edge.status === "depth-exceeded"),
+            ).toBe(true);
+            expect(
+                result.expansionDiagnostics.some(
+                    (diagnostic) =>
+                        diagnostic.ruleId ===
+                        "instruction/import-depth-exceeded",
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe("given a direct import cycle", () => {
+        it("should leave the cyclic edge unexpanded and emit a cycle diagnostic", async () => {
+            await writeFile(join(repoRoot, "a.md"), "A\n@./b.md\n");
+            await writeFile(join(repoRoot, "b.md"), "B\n@./a.md\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "a.md",
+            });
+
+            expect(result.content).toContain("A\n");
+            expect(result.content).toContain("B\n");
+            expect(result.content).toContain("@./a.md");
+            expect(result.edges.some((edge) => edge.status === "cycle")).toBe(
+                true,
+            );
+            expect(
+                result.expansionDiagnostics.some(
+                    (diagnostic) =>
+                        diagnostic.ruleId === "instruction/import-cycle",
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe("given an indirect import cycle", () => {
+        it("should detect the cycle through an intermediate file", async () => {
+            await writeFile(join(repoRoot, "a.md"), "@./b.md\n");
+            await writeFile(join(repoRoot, "b.md"), "@./c.md\n");
+            await writeFile(join(repoRoot, "c.md"), "@./a.md\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "a.md",
+            });
+
+            expect(result.edges.some((edge) => edge.status === "cycle")).toBe(
+                true,
+            );
+            expect(
+                result.expansionDiagnostics.some(
+                    (diagnostic) =>
+                        diagnostic.ruleId === "instruction/import-cycle",
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe("given a missing import target", () => {
+        it("should keep the token and emit an unresolved diagnostic", async () => {
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@./missing.md\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("@./missing.md\n");
+            expect(result.edges[0]?.status).toBe("unresolved");
+            expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                "instruction/import-unresolved",
+            );
+        });
+    });
+
+    describe("given a symlink import target", () => {
+        it.skipIf(process.platform === "win32")(
+            "should reject the symlink without reading through it",
+            async () => {
+                await writeFile(join(repoRoot, "real.md"), "secret\n");
+                await symlink(
+                    join(repoRoot, "real.md"),
+                    join(repoRoot, "link.md"),
+                );
+                await writeFile(join(repoRoot, "CLAUDE.md"), "@./link.md\n");
+
+                const result = await buildEffectiveDocument({
+                    repoRoot,
+                    rootRelativePath: "CLAUDE.md",
+                });
+
+                expect(result.content).toBe("@./link.md\n");
+                expect(result.content).not.toContain("secret");
+                expect(result.edges[0]?.status).toBe("symlink");
+                expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                    "instruction/import-symlink",
+                );
+            },
+        );
+    });
+
+    describe("given a path that escapes the repository root", () => {
+        it("should reject the escape and leave the token unexpanded", async () => {
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@../outside.md\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("@../outside.md\n");
+            expect(result.edges[0]?.status).toBe("escape");
+            expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                "instruction/import-escape",
+            );
+        });
+    });
+
+    describe("given @ tokens inside code spans or fenced code", () => {
+        it("should not treat fenced or inline code @paths as imports", async () => {
+            const rootBody = [
+                "Intro",
+                "",
+                "```",
+                "@./secret.md",
+                "```",
+                "",
+                "Use `@./inline.md` in docs.",
+                "",
+                "@./real.md",
+                "",
+            ].join("\n");
+            await writeFile(join(repoRoot, "CLAUDE.md"), rootBody);
+            await writeFile(join(repoRoot, "secret.md"), "NOPE\n");
+            await writeFile(join(repoRoot, "inline.md"), "NOPE\n");
+            await writeFile(join(repoRoot, "real.md"), "YES\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toContain("@./secret.md");
+            expect(result.content).toContain("`@./inline.md`");
+            expect(result.content).toContain("YES\n");
+            expect(result.content).not.toContain("NOPE");
+            expect(result.edges).toHaveLength(1);
+            expect(result.edges[0]?.status).toBe("resolved");
+            expect(result.edges[0]?.target).toBe("real.md");
+        });
+    });
+
+    describe("given the same file imported at two positions", () => {
+        it("should expand both occurrences and count emitted bytes twice", async () => {
+            await writeFile(
+                join(repoRoot, "CLAUDE.md"),
+                "one\n@./shared.md\ntwo\n@./shared.md\n",
+            );
+            await writeFile(join(repoRoot, "shared.md"), "SHARED\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("one\nSHARED\n\ntwo\nSHARED\n\n");
+            expect(
+                result.edges.filter((edge) => edge.status === "resolved"),
+            ).toHaveLength(2);
+            const sharedSegments = result.orderedSegments.filter(
+                (segment) => segment.sourcePath === "shared.md",
+            );
+            expect(sharedSegments.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    describe("given absolute and home-prefixed import targets", () => {
+        it("should reject absolute paths", async () => {
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@/etc/passwd\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("@/etc/passwd\n");
+            expect(result.edges[0]?.status).toBe("absolute");
+            expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                "instruction/import-escape",
+            );
+        });
+
+        it("should reject home-prefixed paths", async () => {
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@~/secrets.md\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("@~/secrets.md\n");
+            expect(result.edges[0]?.status).toBe("home");
+            expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                "instruction/import-escape",
+            );
+        });
+    });
+
+    describe("given one bad import and one good import in the same file", () => {
+        it("should expand the valid edge and leave the failed edge unexpanded", async () => {
+            await writeFile(
+                join(repoRoot, "CLAUDE.md"),
+                "start\n@./missing.md\nmiddle\n@./good.md\nend\n",
+            );
+            await writeFile(join(repoRoot, "good.md"), "GOOD\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe(
+                "start\n@./missing.md\nmiddle\nGOOD\n\nend\n",
+            );
+            expect(result.edges).toHaveLength(2);
+            expect(result.edges[0]?.status).toBe("unresolved");
+            expect(result.edges[1]?.status).toBe("resolved");
+            expect(result.expansionDiagnostics).toHaveLength(1);
+            expect(result.expansionDiagnostics[0]?.ruleId).toBe(
+                "instruction/import-unresolved",
+            );
+        });
+    });
+
+    describe("given an import resolved from a nested importer directory", () => {
+        it("should resolve the target relative to the importer directory", async () => {
+            await mkdir(join(repoRoot, "docs"), { recursive: true });
+            await writeFile(join(repoRoot, "CLAUDE.md"), "@./docs/index.md\n");
+            await writeFile(join(repoRoot, "docs/index.md"), "@./note.md\n");
+            await writeFile(join(repoRoot, "docs/note.md"), "NOTE\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("NOTE\n\n\n");
+            expect(
+                result.edges.every((edge) => edge.status === "resolved"),
+            ).toBe(true);
+        });
+    });
+
+    describe("given exported default limits", () => {
+        it("should expose conservative named defaults", () => {
+            expect(DEFAULT_MAX_IMPORT_DEPTH).toBe(4);
+            expect(DEFAULT_MAX_UNIQUE_FILES).toBe(64);
+            expect(DEFAULT_MAX_EMITTED_BYTES).toBe(512_000);
+        });
+    });
+
+    describe("given a Markdown link that is not a hard import", () => {
+        it("should not expand ordinary markdown links", async () => {
+            await writeFile(
+                join(repoRoot, "CLAUDE.md"),
+                "See [agents](./AGENTS.md)\n",
+            );
+            await writeFile(join(repoRoot, "AGENTS.md"), "SHOULD-NOT-APPEAR\n");
+
+            const result = await buildEffectiveDocument({
+                repoRoot,
+                rootRelativePath: "CLAUDE.md",
+            });
+
+            expect(result.content).toBe("See [agents](./AGENTS.md)\n");
+            expect(result.edges).toHaveLength(0);
+            expect(result.content).not.toContain("SHOULD-NOT-APPEAR");
+        });
+    });
+});

--- a/packages/core/src/lib/instruction-import-expand.ts
+++ b/packages/core/src/lib/instruction-import-expand.ts
@@ -493,30 +493,56 @@ class ExpansionSession {
     }
 }
 
-interface ContentBuilder {
-    output: string;
-    segments: EffectiveSegment[];
-}
+class ContentBuilder {
+    private outputText = "";
+    private readonly builtSegments: EffectiveSegment[] = [];
 
-function appendEmittedLiteral(
-    builder: ContentBuilder,
-    sourcePath: string,
-    sourceStart: number,
-    text: string,
-    importChain: readonly string[],
-): void {
-    const segment = createLiteralSegment(
-        builder.output.length,
-        sourcePath,
-        sourceStart,
-        text,
-        importChain,
-    );
-    if (!segment) {
-        return;
+    get output(): string {
+        return this.outputText;
     }
-    builder.segments.push(segment);
-    builder.output += text;
+
+    get length(): number {
+        return this.outputText.length;
+    }
+
+    get segments(): readonly EffectiveSegment[] {
+        return this.builtSegments;
+    }
+
+    appendLiteral(
+        sourcePath: string,
+        sourceStart: number,
+        text: string,
+        importChain: readonly string[],
+    ): void {
+        const segment = createLiteralSegment(
+            this.outputText.length,
+            sourcePath,
+            sourceStart,
+            text,
+            importChain,
+        );
+        if (!segment) {
+            return;
+        }
+        this.builtSegments.push(segment);
+        this.outputText += text;
+    }
+
+    appendExpanded(
+        content: string,
+        segments: readonly EffectiveSegment[],
+    ): void {
+        this.outputText += content;
+        this.builtSegments.push(...segments);
+    }
+
+    toResult(): ExpandResult {
+        return {
+            content: this.outputText,
+            segments: [...this.builtSegments],
+        };
+    }
 }
 
 function emitSourceSlice(
@@ -534,7 +560,7 @@ function emitSourceSlice(
     const { emitted, complete } = session.takeEmitBudget(
         content.slice(from, to),
     );
-    appendEmittedLiteral(builder, sourcePath, from, emitted, importChain);
+    builder.appendLiteral(sourcePath, from, emitted, importChain);
     return complete;
 }
 
@@ -618,7 +644,7 @@ async function expandContent(
     importChain: readonly string[],
 ): Promise<ExpandResult> {
     const tokens = findImportTokens(content);
-    const builder: ContentBuilder = { output: "", segments: [] };
+    const builder = new ContentBuilder();
     let cursor = 0;
 
     for (const token of tokens) {
@@ -642,7 +668,7 @@ async function expandContent(
                 content.length,
                 importChain,
             );
-            return { content: builder.output, segments: builder.segments };
+            return builder.toResult();
         }
 
         const expansion = await expandToken(
@@ -653,12 +679,11 @@ async function expandContent(
             hop,
             stack,
             importChain,
-            builder.output.length,
+            builder.length,
         );
 
         if (expansion.kind === "expanded") {
-            builder.output += expansion.content;
-            builder.segments.push(...expansion.segments);
+            builder.appendExpanded(expansion.content, expansion.segments);
         } else {
             const tokenOk = emitSourceSlice(
                 session,
@@ -670,7 +695,7 @@ async function expandContent(
                 importChain,
             );
             if (!tokenOk) {
-                return { content: builder.output, segments: builder.segments };
+                return builder.toResult();
             }
         }
 
@@ -686,7 +711,7 @@ async function expandContent(
         content.length,
         importChain,
     );
-    return { content: builder.output, segments: builder.segments };
+    return builder.toResult();
 }
 
 /**

--- a/packages/core/src/lib/instruction-import-expand.ts
+++ b/packages/core/src/lib/instruction-import-expand.ts
@@ -217,54 +217,50 @@ function createLiteralSegment(
     };
 }
 
+const RULE_ID_BY_STATUS = {
+    unresolved: "instruction/import-unresolved",
+    "not-regular": "instruction/import-unresolved",
+    escape: "instruction/import-escape",
+    absolute: "instruction/import-escape",
+    home: "instruction/import-escape",
+    symlink: "instruction/import-symlink",
+    cycle: "instruction/import-cycle",
+    "depth-exceeded": "instruction/import-depth-exceeded",
+    "size-exceeded": "instruction/import-size-exceeded",
+    resolved: undefined,
+} as const satisfies Record<ImportEdgeStatus, string | undefined>;
+
+const FAILURE_MESSAGE_BY_STATUS = {
+    unresolved: (rawTarget: string) =>
+        `Import target could not be resolved: ${rawTarget}`,
+    escape: (rawTarget: string) =>
+        `Import target escapes the repository root: ${rawTarget}`,
+    absolute: (rawTarget: string) =>
+        `Absolute import paths are not allowed: ${rawTarget}`,
+    home: (rawTarget: string) =>
+        `Home-directory import paths are not allowed: ${rawTarget}`,
+    symlink: (rawTarget: string) =>
+        `Import target path contains a symbolic link: ${rawTarget}`,
+    cycle: (rawTarget: string) =>
+        `Import cycle detected while resolving: ${rawTarget}`,
+    "depth-exceeded": (rawTarget: string) =>
+        `Import depth limit exceeded while resolving: ${rawTarget}`,
+    "size-exceeded": (rawTarget: string) =>
+        `Import expansion size or graph limit exceeded while resolving: ${rawTarget}`,
+    "not-regular": (rawTarget: string) =>
+        `Import target is not a regular file: ${rawTarget}`,
+    resolved: () => "",
+} as const satisfies Record<ImportEdgeStatus, (rawTarget: string) => string>;
+
 function ruleIdForStatus(status: ImportEdgeStatus): string | undefined {
-    switch (status) {
-        case "unresolved":
-        case "not-regular":
-            return "instruction/import-unresolved";
-        case "escape":
-        case "absolute":
-        case "home":
-            return "instruction/import-escape";
-        case "symlink":
-            return "instruction/import-symlink";
-        case "cycle":
-            return "instruction/import-cycle";
-        case "depth-exceeded":
-            return "instruction/import-depth-exceeded";
-        case "size-exceeded":
-            return "instruction/import-size-exceeded";
-        case "resolved":
-            return undefined;
-    }
+    return RULE_ID_BY_STATUS[status];
 }
 
 function messageForFailure(
     status: ImportEdgeStatus,
     rawTarget: string,
 ): string {
-    switch (status) {
-        case "unresolved":
-            return `Import target could not be resolved: ${rawTarget}`;
-        case "escape":
-            return `Import target escapes the repository root: ${rawTarget}`;
-        case "absolute":
-            return `Absolute import paths are not allowed: ${rawTarget}`;
-        case "home":
-            return `Home-directory import paths are not allowed: ${rawTarget}`;
-        case "symlink":
-            return `Import target path contains a symbolic link: ${rawTarget}`;
-        case "cycle":
-            return `Import cycle detected while resolving: ${rawTarget}`;
-        case "depth-exceeded":
-            return `Import depth limit exceeded while resolving: ${rawTarget}`;
-        case "size-exceeded":
-            return `Import expansion size or graph limit exceeded while resolving: ${rawTarget}`;
-        case "not-regular":
-            return `Import target is not a regular file: ${rawTarget}`;
-        case "resolved":
-            return "";
-    }
+    return FAILURE_MESSAGE_BY_STATUS[status](rawTarget);
 }
 
 function classifyPathError(error: unknown): ImportEdgeStatus {

--- a/packages/core/src/lib/instruction-import-expand.ts
+++ b/packages/core/src/lib/instruction-import-expand.ts
@@ -91,17 +91,16 @@ interface ImportToken {
 
 interface ExpandResult {
     readonly content: string;
-    readonly segments: EffectiveSegment[];
+    readonly segments: readonly EffectiveSegment[];
 }
 
-interface MutableState {
-    readonly limits: ExpansionLimits;
-    readonly contentCache: Map<string, string>;
-    readonly uniqueFiles: Set<string>;
-    readonly edges: ImportEdge[];
-    readonly diagnostics: ExpansionDiagnostic[];
-    emittedBytes: number;
-}
+type TokenExpansion =
+    | {
+          kind: "expanded";
+          content: string;
+          segments: readonly EffectiveSegment[];
+      }
+    | { kind: "unexpanded" };
 
 function resolveLimits(
     overrides: Partial<ExpansionLimits> | undefined,
@@ -129,11 +128,17 @@ function isInsideCodeRegion(
     );
 }
 
-function findCodeRegions(content: string): TextRange[] {
+function collectRegexRanges(
+    content: string,
+    pattern: RegExp,
+    skipInside?: readonly TextRange[],
+): TextRange[] {
     const regions: TextRange[] = [];
-
-    for (const match of content.matchAll(FENCED_CODE_RE)) {
+    for (const match of content.matchAll(pattern)) {
         if (match.index === undefined) {
+            continue;
+        }
+        if (skipInside && isInsideCodeRegion(match.index, skipInside)) {
             continue;
         }
         regions.push({
@@ -141,21 +146,13 @@ function findCodeRegions(content: string): TextRange[] {
             end: match.index + match[0].length,
         });
     }
-
-    for (const match of content.matchAll(INLINE_CODE_RE)) {
-        if (match.index === undefined) {
-            continue;
-        }
-        if (isInsideCodeRegion(match.index, regions)) {
-            continue;
-        }
-        regions.push({
-            start: match.index,
-            end: match.index + match[0].length,
-        });
-    }
-
     return regions;
+}
+
+function findCodeRegions(content: string): TextRange[] {
+    const fenced = collectRegexRanges(content, FENCED_CODE_RE);
+    const inline = collectRegexRanges(content, INLINE_CODE_RE, fenced);
+    return [...fenced, ...inline];
 }
 
 function findImportTokens(content: string): ImportToken[] {
@@ -196,18 +193,17 @@ function rebaseSegments(
     }));
 }
 
-function appendLiteralSegment(
-    segments: EffectiveSegment[],
+function createLiteralSegment(
     contentOffset: number,
     sourcePath: string,
     sourceStart: number,
     text: string,
     importChain: readonly string[],
-): void {
+): EffectiveSegment | undefined {
     if (text.length === 0) {
-        return;
+        return undefined;
     }
-    segments.push({
+    return {
         effectiveRange: {
             start: contentOffset,
             end: contentOffset + text.length,
@@ -218,12 +214,13 @@ function appendLiteralSegment(
             end: sourceStart + text.length,
         },
         importChain: [...importChain],
-    });
+    };
 }
 
 function ruleIdForStatus(status: ImportEdgeStatus): string | undefined {
     switch (status) {
         case "unresolved":
+        case "not-regular":
             return "instruction/import-unresolved";
         case "escape":
         case "absolute":
@@ -237,8 +234,6 @@ function ruleIdForStatus(status: ImportEdgeStatus): string | undefined {
             return "instruction/import-depth-exceeded";
         case "size-exceeded":
             return "instruction/import-size-exceeded";
-        case "not-regular":
-            return "instruction/import-unresolved";
         case "resolved":
             return undefined;
     }
@@ -272,19 +267,6 @@ function messageForFailure(
     }
 }
 
-function recordEdge(state: MutableState, edge: ImportEdge): void {
-    state.edges.push(edge);
-    if (edge.status === "resolved" || !edge.ruleId) {
-        return;
-    }
-    state.diagnostics.push({
-        ruleId: edge.ruleId,
-        message: messageForFailure(edge.status, edge.rawTarget),
-        filePath: edge.importer,
-        range: edge.tokenRange,
-    });
-}
-
 function classifyPathError(error: unknown): ImportEdgeStatus {
     if (!(error instanceof Error)) {
         return "unresolved";
@@ -309,12 +291,6 @@ function classifyPathError(error: unknown): ImportEdgeStatus {
         message.includes("too-large")
     ) {
         return "size-exceeded";
-    }
-    if ("code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
-        return "unresolved";
-    }
-    if (message.includes("ENOENT") || message.includes("not found")) {
-        return "unresolved";
     }
     return "unresolved";
 }
@@ -356,228 +332,231 @@ function normalizeRelativeWithinRoot(
     return { ok: true, relativePath: toPosixRelative(normalized) };
 }
 
-async function readCachedFile(
-    repoRoot: string,
-    relativePath: string,
-    state: MutableState,
-): Promise<
-    | { ok: true; content: string; isNewUnique: boolean }
-    | { ok: false; status: ImportEdgeStatus }
-> {
-    const cached = state.contentCache.get(relativePath);
-    if (cached !== undefined) {
-        return { ok: true, content: cached, isNewUnique: false };
-    }
-
-    try {
-        await resolvePathWithinRoot(repoRoot, relativePath);
-    } catch (error: unknown) {
-        return { ok: false, status: classifyPathError(error) };
-    }
-
-    try {
-        const stats = await statWithinRoot(repoRoot, relativePath);
-        if (stats.isSymbolicLink) {
-            return { ok: false, status: "symlink" };
-        }
-        if (!stats.isFile) {
-            return { ok: false, status: "not-regular" };
-        }
-    } catch (error: unknown) {
-        return { ok: false, status: classifyPathError(error) };
-    }
-
-    const isNewUnique = !state.uniqueFiles.has(relativePath);
-    if (isNewUnique && state.uniqueFiles.size >= state.limits.maxUniqueFiles) {
-        return { ok: false, status: "size-exceeded" };
-    }
-
-    try {
-        const content = await readTextWithinRoot(
-            repoRoot,
-            relativePath,
-            state.limits.maxFileBytes,
-        );
-        state.contentCache.set(relativePath, content);
-        if (isNewUnique) {
-            state.uniqueFiles.add(relativePath);
-        }
-        return { ok: true, content, isNewUnique };
-    } catch (error: unknown) {
-        return { ok: false, status: classifyPathError(error) };
-    }
+function isUnsafeRootPath(rootRelativePath: string): boolean {
+    return (
+        !rootRelativePath ||
+        rootRelativePath === ".." ||
+        rootRelativePath.startsWith(`..${sep}`) ||
+        rootRelativePath.startsWith("../") ||
+        isAbsolute(rootRelativePath)
+    );
 }
 
-async function expandContent(
-    repoRoot: string,
-    sourcePath: string,
-    content: string,
-    hop: number,
-    stack: readonly string[],
-    importChain: readonly string[],
-    state: MutableState,
-): Promise<ExpandResult> {
-    const tokens = findImportTokens(content);
-    const segments: EffectiveSegment[] = [];
-    let output = "";
-    let cursor = 0;
+/**
+ * Owns expansion bookkeeping for a single buildEffectiveDocument call.
+ * Mutations stay on the session instance rather than shared parameter bags.
+ */
+class ExpansionSession {
+    readonly limits: ExpansionLimits;
+    private readonly contentCache = new Map<string, string>();
+    private readonly uniqueFiles = new Set<string>();
+    private readonly edges: ImportEdge[] = [];
+    private readonly diagnostics: ExpansionDiagnostic[] = [];
+    private emittedBytes = 0;
 
-    const flushLiteral = (from: number, to: number): boolean => {
-        if (to <= from) {
-            return true;
-        }
-        const text = content.slice(from, to);
-        if (state.emittedBytes + text.length > state.limits.maxEmittedBytes) {
-            return false;
-        }
-        appendLiteralSegment(
-            segments,
-            output.length,
-            sourcePath,
-            from,
-            text,
-            importChain,
-        );
-        output += text;
-        state.emittedBytes += text.length;
-        return true;
-    };
-
-    for (const token of tokens) {
-        if (!flushLiteral(cursor, token.start)) {
-            recordEdge(state, {
-                importer: sourcePath,
-                tokenRange: { start: token.start, end: token.end },
-                rawTarget: token.rawTarget,
-                status: "size-exceeded",
-                ruleId: ruleIdForStatus("size-exceeded"),
-            });
-            // Keep remaining source literal if possible, else stop.
-            const rest = content.slice(token.start);
-            const room = state.limits.maxEmittedBytes - state.emittedBytes;
-            if (room > 0) {
-                const clipped = rest.slice(0, room);
-                appendLiteralSegment(
-                    segments,
-                    output.length,
-                    sourcePath,
-                    token.start,
-                    clipped,
-                    importChain,
-                );
-                output += clipped;
-                state.emittedBytes += clipped.length;
-            }
-            return { content: output, segments };
-        }
-
-        const expansion = await expandToken(
-            repoRoot,
-            sourcePath,
-            token,
-            hop,
-            stack,
-            importChain,
-            state,
-            output.length,
-        );
-
-        if (expansion.kind === "expanded") {
-            output += expansion.content;
-            segments.push(...expansion.segments);
-        } else {
-            const tokenText = content.slice(token.start, token.end);
-            if (
-                state.emittedBytes + tokenText.length >
-                state.limits.maxEmittedBytes
-            ) {
-                const room = state.limits.maxEmittedBytes - state.emittedBytes;
-                if (room > 0) {
-                    const clipped = tokenText.slice(0, room);
-                    appendLiteralSegment(
-                        segments,
-                        output.length,
-                        sourcePath,
-                        token.start,
-                        clipped,
-                        importChain,
-                    );
-                    output += clipped;
-                    state.emittedBytes += clipped.length;
-                }
-                return { content: output, segments };
-            }
-            appendLiteralSegment(
-                segments,
-                output.length,
-                sourcePath,
-                token.start,
-                tokenText,
-                importChain,
-            );
-            output += tokenText;
-            state.emittedBytes += tokenText.length;
-        }
-
-        cursor = token.end;
+    constructor(limits: ExpansionLimits) {
+        this.limits = limits;
     }
 
-    if (!flushLiteral(cursor, content.length)) {
-        const rest = content.slice(cursor);
-        const room = state.limits.maxEmittedBytes - state.emittedBytes;
-        if (room > 0) {
-            const clipped = rest.slice(0, room);
-            appendLiteralSegment(
-                segments,
-                output.length,
-                sourcePath,
-                cursor,
-                clipped,
-                importChain,
-            );
-            output += clipped;
-            state.emittedBytes += clipped.length;
-        }
+    get edgeCount(): number {
+        return this.edges.length;
     }
 
-    return { content: output, segments };
-}
+    get remainingEmitBudget(): number {
+        return this.limits.maxEmittedBytes - this.emittedBytes;
+    }
 
-async function expandToken(
-    repoRoot: string,
-    importerPath: string,
-    token: ImportToken,
-    hop: number,
-    stack: readonly string[],
-    importChain: readonly string[],
-    state: MutableState,
-    outputOffset: number,
-): Promise<
-    | { kind: "expanded"; content: string; segments: EffectiveSegment[] }
-    | { kind: "unexpanded" }
-> {
-    const fail = (
+    isEmitBudgetExhausted(): boolean {
+        return this.emittedBytes >= this.limits.maxEmittedBytes;
+    }
+
+    snapshot(): {
+        edges: readonly ImportEdge[];
+        diagnostics: readonly ExpansionDiagnostic[];
+    } {
+        return {
+            edges: [...this.edges],
+            diagnostics: [...this.diagnostics],
+        };
+    }
+
+    recordEdge(edge: ImportEdge): void {
+        this.edges.push(edge);
+        if (edge.status === "resolved" || !edge.ruleId) {
+            return;
+        }
+        this.diagnostics.push({
+            ruleId: edge.ruleId,
+            message: messageForFailure(edge.status, edge.rawTarget),
+            filePath: edge.importer,
+            range: edge.tokenRange,
+        });
+    }
+
+    recordFailure(
+        importer: string,
+        token: ImportToken,
         status: ImportEdgeStatus,
         target?: string,
-    ): { kind: "unexpanded" } => {
-        recordEdge(state, {
-            importer: importerPath,
+    ): void {
+        this.recordEdge({
+            importer,
             tokenRange: { start: token.start, end: token.end },
             rawTarget: token.rawTarget,
             target,
             status,
             ruleId: ruleIdForStatus(status),
         });
-        return { kind: "unexpanded" };
-    };
+    }
 
-    if (state.edges.length >= state.limits.maxEdges) {
-        return fail("size-exceeded");
+    recordResolved(importer: string, token: ImportToken, target: string): void {
+        this.recordEdge({
+            importer,
+            tokenRange: { start: token.start, end: token.end },
+            rawTarget: token.rawTarget,
+            target,
+            status: "resolved",
+        });
+    }
+
+    /**
+     * Emit up to `text` against the remaining byte budget.
+     * Returns emitted text (possibly clipped) and whether the full text fit.
+     */
+    takeEmitBudget(text: string): { emitted: string; complete: boolean } {
+        if (text.length === 0) {
+            return { emitted: "", complete: true };
+        }
+        const room = this.remainingEmitBudget;
+        if (room <= 0) {
+            return { emitted: "", complete: false };
+        }
+        if (text.length <= room) {
+            this.emittedBytes += text.length;
+            return { emitted: text, complete: true };
+        }
+        this.emittedBytes += room;
+        return { emitted: text.slice(0, room), complete: false };
+    }
+
+    async readFile(
+        repoRoot: string,
+        relativePath: string,
+    ): Promise<
+        { ok: true; content: string } | { ok: false; status: ImportEdgeStatus }
+    > {
+        const cached = this.contentCache.get(relativePath);
+        if (cached !== undefined) {
+            return { ok: true, content: cached };
+        }
+
+        try {
+            await resolvePathWithinRoot(repoRoot, relativePath);
+        } catch (error: unknown) {
+            return { ok: false, status: classifyPathError(error) };
+        }
+
+        try {
+            const stats = await statWithinRoot(repoRoot, relativePath);
+            if (stats.isSymbolicLink) {
+                return { ok: false, status: "symlink" };
+            }
+            if (!stats.isFile) {
+                return { ok: false, status: "not-regular" };
+            }
+        } catch (error: unknown) {
+            return { ok: false, status: classifyPathError(error) };
+        }
+
+        const isNewUnique = !this.uniqueFiles.has(relativePath);
+        if (
+            isNewUnique &&
+            this.uniqueFiles.size >= this.limits.maxUniqueFiles
+        ) {
+            return { ok: false, status: "size-exceeded" };
+        }
+
+        try {
+            const content = await readTextWithinRoot(
+                repoRoot,
+                relativePath,
+                this.limits.maxFileBytes,
+            );
+            this.contentCache.set(relativePath, content);
+            if (isNewUnique) {
+                this.uniqueFiles.add(relativePath);
+            }
+            return { ok: true, content };
+        } catch (error: unknown) {
+            return { ok: false, status: classifyPathError(error) };
+        }
+    }
+}
+
+interface ContentBuilder {
+    output: string;
+    segments: EffectiveSegment[];
+}
+
+function appendEmittedLiteral(
+    builder: ContentBuilder,
+    sourcePath: string,
+    sourceStart: number,
+    text: string,
+    importChain: readonly string[],
+): void {
+    const segment = createLiteralSegment(
+        builder.output.length,
+        sourcePath,
+        sourceStart,
+        text,
+        importChain,
+    );
+    if (!segment) {
+        return;
+    }
+    builder.segments.push(segment);
+    builder.output += text;
+}
+
+function emitSourceSlice(
+    session: ExpansionSession,
+    builder: ContentBuilder,
+    sourcePath: string,
+    content: string,
+    from: number,
+    to: number,
+    importChain: readonly string[],
+): boolean {
+    if (to <= from) {
+        return true;
+    }
+    const { emitted, complete } = session.takeEmitBudget(
+        content.slice(from, to),
+    );
+    appendEmittedLiteral(builder, sourcePath, from, emitted, importChain);
+    return complete;
+}
+
+async function expandToken(
+    session: ExpansionSession,
+    repoRoot: string,
+    importerPath: string,
+    token: ImportToken,
+    hop: number,
+    stack: readonly string[],
+    importChain: readonly string[],
+    outputOffset: number,
+): Promise<TokenExpansion> {
+    if (session.edgeCount >= session.limits.maxEdges) {
+        session.recordFailure(importerPath, token, "size-exceeded");
+        return { kind: "unexpanded" };
     }
 
     const nextHop = hop + 1;
-    if (nextHop > state.limits.maxDepth) {
-        return fail("depth-exceeded");
+    if (nextHop > session.limits.maxDepth) {
+        session.recordFailure(importerPath, token, "depth-exceeded");
+        return { kind: "unexpanded" };
     }
 
     const normalized = normalizeRelativeWithinRoot(
@@ -585,50 +564,129 @@ async function expandToken(
         token.rawTarget,
     );
     if (!normalized.ok) {
-        return fail(normalized.status);
+        session.recordFailure(importerPath, token, normalized.status);
+        return { kind: "unexpanded" };
     }
 
     const targetPath = normalized.relativePath;
-
     if (stack.includes(targetPath)) {
-        return fail("cycle", targetPath);
+        session.recordFailure(importerPath, token, "cycle", targetPath);
+        return { kind: "unexpanded" };
     }
 
-    // Pre-check emitted budget with a zero-length probe: actual size checked after read.
-    const readResult = await readCachedFile(repoRoot, targetPath, state);
+    const readResult = await session.readFile(repoRoot, targetPath);
     if (!readResult.ok) {
-        return fail(readResult.status, targetPath);
+        session.recordFailure(
+            importerPath,
+            token,
+            readResult.status,
+            targetPath,
+        );
+        return { kind: "unexpanded" };
     }
 
-    if (state.emittedBytes >= state.limits.maxEmittedBytes) {
-        return fail("size-exceeded", targetPath);
+    if (session.isEmitBudgetExhausted()) {
+        session.recordFailure(importerPath, token, "size-exceeded", targetPath);
+        return { kind: "unexpanded" };
     }
 
-    // Temporarily reserve uniqueness already handled in readCachedFile.
     const child = await expandContent(
+        session,
         repoRoot,
         targetPath,
         readResult.content,
         nextHop,
         [...stack, targetPath],
         [...importChain, targetPath],
-        state,
     );
 
-    // expandContent already accounted emitted bytes for child content.
-    recordEdge(state, {
-        importer: importerPath,
-        tokenRange: { start: token.start, end: token.end },
-        rawTarget: token.rawTarget,
-        target: targetPath,
-        status: "resolved",
-    });
-
+    session.recordResolved(importerPath, token, targetPath);
     return {
         kind: "expanded",
         content: child.content,
         segments: rebaseSegments(child.segments, outputOffset),
     };
+}
+
+async function expandContent(
+    session: ExpansionSession,
+    repoRoot: string,
+    sourcePath: string,
+    content: string,
+    hop: number,
+    stack: readonly string[],
+    importChain: readonly string[],
+): Promise<ExpandResult> {
+    const tokens = findImportTokens(content);
+    const builder: ContentBuilder = { output: "", segments: [] };
+    let cursor = 0;
+
+    for (const token of tokens) {
+        const literalOk = emitSourceSlice(
+            session,
+            builder,
+            sourcePath,
+            content,
+            cursor,
+            token.start,
+            importChain,
+        );
+        if (!literalOk) {
+            session.recordFailure(sourcePath, token, "size-exceeded");
+            emitSourceSlice(
+                session,
+                builder,
+                sourcePath,
+                content,
+                token.start,
+                content.length,
+                importChain,
+            );
+            return { content: builder.output, segments: builder.segments };
+        }
+
+        const expansion = await expandToken(
+            session,
+            repoRoot,
+            sourcePath,
+            token,
+            hop,
+            stack,
+            importChain,
+            builder.output.length,
+        );
+
+        if (expansion.kind === "expanded") {
+            builder.output += expansion.content;
+            builder.segments.push(...expansion.segments);
+        } else {
+            const tokenOk = emitSourceSlice(
+                session,
+                builder,
+                sourcePath,
+                content,
+                token.start,
+                token.end,
+                importChain,
+            );
+            if (!tokenOk) {
+                return { content: builder.output, segments: builder.segments };
+            }
+        }
+
+        cursor = token.end;
+    }
+
+    emitSourceSlice(
+        session,
+        builder,
+        sourcePath,
+        content,
+        cursor,
+        content.length,
+        importChain,
+    );
+    return { content: builder.output, segments: builder.segments };
 }
 
 /**
@@ -640,55 +698,36 @@ export async function buildEffectiveDocument(
     const limits = resolveLimits(input.limits);
     const rootRelativePath = toPosixRelative(normalize(input.rootRelativePath));
 
-    if (
-        !rootRelativePath ||
-        rootRelativePath === ".." ||
-        rootRelativePath.startsWith(`..${sep}`) ||
-        rootRelativePath.startsWith("../") ||
-        isAbsolute(rootRelativePath)
-    ) {
+    if (isUnsafeRootPath(rootRelativePath)) {
         throw new Error(
             `Root path is outside repository root: ${input.rootRelativePath}`,
         );
     }
 
-    const state: MutableState = {
-        limits,
-        contentCache: new Map(),
-        uniqueFiles: new Set(),
-        edges: [],
-        diagnostics: [],
-        emittedBytes: 0,
-    };
-
-    const rootRead = await readCachedFile(
-        input.repoRoot,
-        rootRelativePath,
-        state,
-    );
+    const session = new ExpansionSession(limits);
+    const rootRead = await session.readFile(input.repoRoot, rootRelativePath);
     if (!rootRead.ok) {
         throw new Error(
             `Unable to read root instruction file ${rootRelativePath}: ${rootRead.status}`,
         );
     }
 
-    // Ensure relative() style identity for stack membership
-    const rootKey = rootRelativePath;
     const expanded = await expandContent(
+        session,
         input.repoRoot,
-        rootKey,
+        rootRelativePath,
         rootRead.content,
         0,
-        [rootKey],
-        [rootKey],
-        state,
+        [rootRelativePath],
+        [rootRelativePath],
     );
+    const snapshot = session.snapshot();
 
     return {
-        root: rootKey,
+        root: rootRelativePath,
         content: expanded.content,
         orderedSegments: expanded.segments,
-        edges: state.edges,
-        expansionDiagnostics: state.diagnostics,
+        edges: snapshot.edges,
+        expansionDiagnostics: snapshot.diagnostics,
     };
 }

--- a/packages/core/src/lib/instruction-import-expand.ts
+++ b/packages/core/src/lib/instruction-import-expand.ts
@@ -1,0 +1,694 @@
+/**
+ * Pure Claude `@` import expander that builds an ordered EffectiveDocument.
+ */
+
+import { dirname, isAbsolute, join, normalize, sep } from "node:path";
+import {
+    readTextWithinRoot,
+    resolvePathWithinRoot,
+    statWithinRoot,
+} from "../gateways/file-system-utils.js";
+
+export const DEFAULT_MAX_IMPORT_DEPTH = 4;
+export const DEFAULT_MAX_UNIQUE_FILES = 64;
+export const DEFAULT_MAX_EDGES = 256;
+export const DEFAULT_MAX_EMITTED_BYTES = 512_000;
+export const DEFAULT_MAX_FILE_BYTES = 1_048_576;
+
+/** Aligns with doctor HARD_IMPORT: line-start `@path` where path includes `/`. */
+const HARD_IMPORT_GLOBAL_RE = /^@([^\s@][^\s]*)/gm;
+
+const FENCED_CODE_RE = /^(`{3,}|~{3,})[^\r\n]*\r?\n[\s\S]*?^\1[ \t]*$/gm;
+const INLINE_CODE_RE = /`+[^`\r\n]*`+/g;
+
+export type ImportEdgeStatus =
+    | "resolved"
+    | "unresolved"
+    | "escape"
+    | "symlink"
+    | "cycle"
+    | "depth-exceeded"
+    | "size-exceeded"
+    | "not-regular"
+    | "absolute"
+    | "home";
+
+export interface TextRange {
+    readonly start: number;
+    readonly end: number;
+}
+
+export interface ImportEdge {
+    readonly importer: string;
+    readonly tokenRange: TextRange;
+    readonly rawTarget: string;
+    readonly target?: string;
+    readonly status: ImportEdgeStatus;
+    readonly ruleId?: string;
+}
+
+export interface EffectiveSegment {
+    readonly effectiveRange: TextRange;
+    readonly sourcePath: string;
+    readonly sourceRange: TextRange;
+    readonly importChain: readonly string[];
+}
+
+export interface ExpansionDiagnostic {
+    readonly ruleId: string;
+    readonly message: string;
+    readonly filePath: string;
+    readonly range?: TextRange;
+}
+
+export interface EffectiveDocument {
+    readonly root: string;
+    readonly content: string;
+    readonly orderedSegments: readonly EffectiveSegment[];
+    readonly edges: readonly ImportEdge[];
+    readonly expansionDiagnostics: readonly ExpansionDiagnostic[];
+}
+
+export interface ExpansionLimits {
+    readonly maxDepth: number;
+    readonly maxUniqueFiles: number;
+    readonly maxEdges: number;
+    readonly maxEmittedBytes: number;
+    readonly maxFileBytes: number;
+}
+
+export interface BuildEffectiveDocumentInput {
+    readonly repoRoot: string;
+    readonly rootRelativePath: string;
+    readonly limits?: Partial<ExpansionLimits>;
+}
+
+interface ImportToken {
+    readonly start: number;
+    readonly end: number;
+    readonly rawTarget: string;
+}
+
+interface ExpandResult {
+    readonly content: string;
+    readonly segments: EffectiveSegment[];
+}
+
+interface MutableState {
+    readonly limits: ExpansionLimits;
+    readonly contentCache: Map<string, string>;
+    readonly uniqueFiles: Set<string>;
+    readonly edges: ImportEdge[];
+    readonly diagnostics: ExpansionDiagnostic[];
+    emittedBytes: number;
+}
+
+function resolveLimits(
+    overrides: Partial<ExpansionLimits> | undefined,
+): ExpansionLimits {
+    return {
+        maxDepth: overrides?.maxDepth ?? DEFAULT_MAX_IMPORT_DEPTH,
+        maxUniqueFiles: overrides?.maxUniqueFiles ?? DEFAULT_MAX_UNIQUE_FILES,
+        maxEdges: overrides?.maxEdges ?? DEFAULT_MAX_EDGES,
+        maxEmittedBytes:
+            overrides?.maxEmittedBytes ?? DEFAULT_MAX_EMITTED_BYTES,
+        maxFileBytes: overrides?.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
+    };
+}
+
+function toPosixRelative(pathValue: string): string {
+    return pathValue.split(sep).join("/");
+}
+
+function isInsideCodeRegion(
+    index: number,
+    regions: readonly TextRange[],
+): boolean {
+    return regions.some(
+        (region) => index >= region.start && index < region.end,
+    );
+}
+
+function findCodeRegions(content: string): TextRange[] {
+    const regions: TextRange[] = [];
+
+    for (const match of content.matchAll(FENCED_CODE_RE)) {
+        if (match.index === undefined) {
+            continue;
+        }
+        regions.push({
+            start: match.index,
+            end: match.index + match[0].length,
+        });
+    }
+
+    for (const match of content.matchAll(INLINE_CODE_RE)) {
+        if (match.index === undefined) {
+            continue;
+        }
+        if (isInsideCodeRegion(match.index, regions)) {
+            continue;
+        }
+        regions.push({
+            start: match.index,
+            end: match.index + match[0].length,
+        });
+    }
+
+    return regions;
+}
+
+function findImportTokens(content: string): ImportToken[] {
+    const codeRegions = findCodeRegions(content);
+    const tokens: ImportToken[] = [];
+
+    for (const match of content.matchAll(HARD_IMPORT_GLOBAL_RE)) {
+        if (match.index === undefined) {
+            continue;
+        }
+        const rawTarget = match[1];
+        if (!rawTarget?.includes("/")) {
+            continue;
+        }
+        if (isInsideCodeRegion(match.index, codeRegions)) {
+            continue;
+        }
+        tokens.push({
+            start: match.index,
+            end: match.index + match[0].length,
+            rawTarget,
+        });
+    }
+
+    return tokens;
+}
+
+function rebaseSegments(
+    segments: readonly EffectiveSegment[],
+    offset: number,
+): EffectiveSegment[] {
+    return segments.map((segment) => ({
+        ...segment,
+        effectiveRange: {
+            start: segment.effectiveRange.start + offset,
+            end: segment.effectiveRange.end + offset,
+        },
+    }));
+}
+
+function appendLiteralSegment(
+    segments: EffectiveSegment[],
+    contentOffset: number,
+    sourcePath: string,
+    sourceStart: number,
+    text: string,
+    importChain: readonly string[],
+): void {
+    if (text.length === 0) {
+        return;
+    }
+    segments.push({
+        effectiveRange: {
+            start: contentOffset,
+            end: contentOffset + text.length,
+        },
+        sourcePath,
+        sourceRange: {
+            start: sourceStart,
+            end: sourceStart + text.length,
+        },
+        importChain: [...importChain],
+    });
+}
+
+function ruleIdForStatus(status: ImportEdgeStatus): string | undefined {
+    switch (status) {
+        case "unresolved":
+            return "instruction/import-unresolved";
+        case "escape":
+        case "absolute":
+        case "home":
+            return "instruction/import-escape";
+        case "symlink":
+            return "instruction/import-symlink";
+        case "cycle":
+            return "instruction/import-cycle";
+        case "depth-exceeded":
+            return "instruction/import-depth-exceeded";
+        case "size-exceeded":
+            return "instruction/import-size-exceeded";
+        case "not-regular":
+            return "instruction/import-unresolved";
+        case "resolved":
+            return undefined;
+    }
+}
+
+function messageForFailure(
+    status: ImportEdgeStatus,
+    rawTarget: string,
+): string {
+    switch (status) {
+        case "unresolved":
+            return `Import target could not be resolved: ${rawTarget}`;
+        case "escape":
+            return `Import target escapes the repository root: ${rawTarget}`;
+        case "absolute":
+            return `Absolute import paths are not allowed: ${rawTarget}`;
+        case "home":
+            return `Home-directory import paths are not allowed: ${rawTarget}`;
+        case "symlink":
+            return `Import target path contains a symbolic link: ${rawTarget}`;
+        case "cycle":
+            return `Import cycle detected while resolving: ${rawTarget}`;
+        case "depth-exceeded":
+            return `Import depth limit exceeded while resolving: ${rawTarget}`;
+        case "size-exceeded":
+            return `Import expansion size or graph limit exceeded while resolving: ${rawTarget}`;
+        case "not-regular":
+            return `Import target is not a regular file: ${rawTarget}`;
+        case "resolved":
+            return "";
+    }
+}
+
+function recordEdge(state: MutableState, edge: ImportEdge): void {
+    state.edges.push(edge);
+    if (edge.status === "resolved" || !edge.ruleId) {
+        return;
+    }
+    state.diagnostics.push({
+        ruleId: edge.ruleId,
+        message: messageForFailure(edge.status, edge.rawTarget),
+        filePath: edge.importer,
+        range: edge.tokenRange,
+    });
+}
+
+function classifyPathError(error: unknown): ImportEdgeStatus {
+    if (!(error instanceof Error)) {
+        return "unresolved";
+    }
+    const message = error.message;
+    if (
+        message.includes("outside target directory") ||
+        message.includes("invalid-path") ||
+        message.includes("outside-workspace")
+    ) {
+        return "escape";
+    }
+    if (
+        message.includes("Symlinks are not allowed") ||
+        message.includes("symbolic link") ||
+        message.includes("path-alias")
+    ) {
+        return "symlink";
+    }
+    if (
+        message.includes("exceeds size limit") ||
+        message.includes("too-large")
+    ) {
+        return "size-exceeded";
+    }
+    if ("code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        return "unresolved";
+    }
+    if (message.includes("ENOENT") || message.includes("not found")) {
+        return "unresolved";
+    }
+    return "unresolved";
+}
+
+function normalizeRelativeWithinRoot(
+    importerRelativePath: string,
+    rawTarget: string,
+):
+    | { ok: true; relativePath: string }
+    | { ok: false; status: ImportEdgeStatus } {
+    if (
+        rawTarget === "~" ||
+        rawTarget.startsWith("~/") ||
+        rawTarget.startsWith("~\\")
+    ) {
+        return { ok: false, status: "home" };
+    }
+    if (isAbsolute(rawTarget)) {
+        return { ok: false, status: "absolute" };
+    }
+
+    const importerDir = dirname(importerRelativePath);
+    const joined = normalize(join(importerDir, rawTarget));
+    const normalized = joined === "." ? "" : joined;
+
+    if (
+        normalized === ".." ||
+        normalized.startsWith(`..${sep}`) ||
+        normalized.startsWith("../") ||
+        normalized.startsWith("..\\")
+    ) {
+        return { ok: false, status: "escape" };
+    }
+
+    if (!normalized) {
+        return { ok: false, status: "unresolved" };
+    }
+
+    return { ok: true, relativePath: toPosixRelative(normalized) };
+}
+
+async function readCachedFile(
+    repoRoot: string,
+    relativePath: string,
+    state: MutableState,
+): Promise<
+    | { ok: true; content: string; isNewUnique: boolean }
+    | { ok: false; status: ImportEdgeStatus }
+> {
+    const cached = state.contentCache.get(relativePath);
+    if (cached !== undefined) {
+        return { ok: true, content: cached, isNewUnique: false };
+    }
+
+    try {
+        await resolvePathWithinRoot(repoRoot, relativePath);
+    } catch (error: unknown) {
+        return { ok: false, status: classifyPathError(error) };
+    }
+
+    try {
+        const stats = await statWithinRoot(repoRoot, relativePath);
+        if (stats.isSymbolicLink) {
+            return { ok: false, status: "symlink" };
+        }
+        if (!stats.isFile) {
+            return { ok: false, status: "not-regular" };
+        }
+    } catch (error: unknown) {
+        return { ok: false, status: classifyPathError(error) };
+    }
+
+    const isNewUnique = !state.uniqueFiles.has(relativePath);
+    if (isNewUnique && state.uniqueFiles.size >= state.limits.maxUniqueFiles) {
+        return { ok: false, status: "size-exceeded" };
+    }
+
+    try {
+        const content = await readTextWithinRoot(
+            repoRoot,
+            relativePath,
+            state.limits.maxFileBytes,
+        );
+        state.contentCache.set(relativePath, content);
+        if (isNewUnique) {
+            state.uniqueFiles.add(relativePath);
+        }
+        return { ok: true, content, isNewUnique };
+    } catch (error: unknown) {
+        return { ok: false, status: classifyPathError(error) };
+    }
+}
+
+async function expandContent(
+    repoRoot: string,
+    sourcePath: string,
+    content: string,
+    hop: number,
+    stack: readonly string[],
+    importChain: readonly string[],
+    state: MutableState,
+): Promise<ExpandResult> {
+    const tokens = findImportTokens(content);
+    const segments: EffectiveSegment[] = [];
+    let output = "";
+    let cursor = 0;
+
+    const flushLiteral = (from: number, to: number): boolean => {
+        if (to <= from) {
+            return true;
+        }
+        const text = content.slice(from, to);
+        if (state.emittedBytes + text.length > state.limits.maxEmittedBytes) {
+            return false;
+        }
+        appendLiteralSegment(
+            segments,
+            output.length,
+            sourcePath,
+            from,
+            text,
+            importChain,
+        );
+        output += text;
+        state.emittedBytes += text.length;
+        return true;
+    };
+
+    for (const token of tokens) {
+        if (!flushLiteral(cursor, token.start)) {
+            recordEdge(state, {
+                importer: sourcePath,
+                tokenRange: { start: token.start, end: token.end },
+                rawTarget: token.rawTarget,
+                status: "size-exceeded",
+                ruleId: ruleIdForStatus("size-exceeded"),
+            });
+            // Keep remaining source literal if possible, else stop.
+            const rest = content.slice(token.start);
+            const room = state.limits.maxEmittedBytes - state.emittedBytes;
+            if (room > 0) {
+                const clipped = rest.slice(0, room);
+                appendLiteralSegment(
+                    segments,
+                    output.length,
+                    sourcePath,
+                    token.start,
+                    clipped,
+                    importChain,
+                );
+                output += clipped;
+                state.emittedBytes += clipped.length;
+            }
+            return { content: output, segments };
+        }
+
+        const expansion = await expandToken(
+            repoRoot,
+            sourcePath,
+            token,
+            hop,
+            stack,
+            importChain,
+            state,
+            output.length,
+        );
+
+        if (expansion.kind === "expanded") {
+            output += expansion.content;
+            segments.push(...expansion.segments);
+        } else {
+            const tokenText = content.slice(token.start, token.end);
+            if (
+                state.emittedBytes + tokenText.length >
+                state.limits.maxEmittedBytes
+            ) {
+                const room = state.limits.maxEmittedBytes - state.emittedBytes;
+                if (room > 0) {
+                    const clipped = tokenText.slice(0, room);
+                    appendLiteralSegment(
+                        segments,
+                        output.length,
+                        sourcePath,
+                        token.start,
+                        clipped,
+                        importChain,
+                    );
+                    output += clipped;
+                    state.emittedBytes += clipped.length;
+                }
+                return { content: output, segments };
+            }
+            appendLiteralSegment(
+                segments,
+                output.length,
+                sourcePath,
+                token.start,
+                tokenText,
+                importChain,
+            );
+            output += tokenText;
+            state.emittedBytes += tokenText.length;
+        }
+
+        cursor = token.end;
+    }
+
+    if (!flushLiteral(cursor, content.length)) {
+        const rest = content.slice(cursor);
+        const room = state.limits.maxEmittedBytes - state.emittedBytes;
+        if (room > 0) {
+            const clipped = rest.slice(0, room);
+            appendLiteralSegment(
+                segments,
+                output.length,
+                sourcePath,
+                cursor,
+                clipped,
+                importChain,
+            );
+            output += clipped;
+            state.emittedBytes += clipped.length;
+        }
+    }
+
+    return { content: output, segments };
+}
+
+async function expandToken(
+    repoRoot: string,
+    importerPath: string,
+    token: ImportToken,
+    hop: number,
+    stack: readonly string[],
+    importChain: readonly string[],
+    state: MutableState,
+    outputOffset: number,
+): Promise<
+    | { kind: "expanded"; content: string; segments: EffectiveSegment[] }
+    | { kind: "unexpanded" }
+> {
+    const fail = (
+        status: ImportEdgeStatus,
+        target?: string,
+    ): { kind: "unexpanded" } => {
+        recordEdge(state, {
+            importer: importerPath,
+            tokenRange: { start: token.start, end: token.end },
+            rawTarget: token.rawTarget,
+            target,
+            status,
+            ruleId: ruleIdForStatus(status),
+        });
+        return { kind: "unexpanded" };
+    };
+
+    if (state.edges.length >= state.limits.maxEdges) {
+        return fail("size-exceeded");
+    }
+
+    const nextHop = hop + 1;
+    if (nextHop > state.limits.maxDepth) {
+        return fail("depth-exceeded");
+    }
+
+    const normalized = normalizeRelativeWithinRoot(
+        importerPath,
+        token.rawTarget,
+    );
+    if (!normalized.ok) {
+        return fail(normalized.status);
+    }
+
+    const targetPath = normalized.relativePath;
+
+    if (stack.includes(targetPath)) {
+        return fail("cycle", targetPath);
+    }
+
+    // Pre-check emitted budget with a zero-length probe: actual size checked after read.
+    const readResult = await readCachedFile(repoRoot, targetPath, state);
+    if (!readResult.ok) {
+        return fail(readResult.status, targetPath);
+    }
+
+    if (state.emittedBytes >= state.limits.maxEmittedBytes) {
+        return fail("size-exceeded", targetPath);
+    }
+
+    // Temporarily reserve uniqueness already handled in readCachedFile.
+    const child = await expandContent(
+        repoRoot,
+        targetPath,
+        readResult.content,
+        nextHop,
+        [...stack, targetPath],
+        [...importChain, targetPath],
+        state,
+    );
+
+    // expandContent already accounted emitted bytes for child content.
+    recordEdge(state, {
+        importer: importerPath,
+        tokenRange: { start: token.start, end: token.end },
+        rawTarget: token.rawTarget,
+        target: targetPath,
+        status: "resolved",
+    });
+
+    return {
+        kind: "expanded",
+        content: child.content,
+        segments: rebaseSegments(child.segments, outputOffset),
+    };
+}
+
+/**
+ * Build an ordered effective document by expanding verified Claude `@` imports.
+ */
+export async function buildEffectiveDocument(
+    input: BuildEffectiveDocumentInput,
+): Promise<EffectiveDocument> {
+    const limits = resolveLimits(input.limits);
+    const rootRelativePath = toPosixRelative(normalize(input.rootRelativePath));
+
+    if (
+        !rootRelativePath ||
+        rootRelativePath === ".." ||
+        rootRelativePath.startsWith(`..${sep}`) ||
+        rootRelativePath.startsWith("../") ||
+        isAbsolute(rootRelativePath)
+    ) {
+        throw new Error(
+            `Root path is outside repository root: ${input.rootRelativePath}`,
+        );
+    }
+
+    const state: MutableState = {
+        limits,
+        contentCache: new Map(),
+        uniqueFiles: new Set(),
+        edges: [],
+        diagnostics: [],
+        emittedBytes: 0,
+    };
+
+    const rootRead = await readCachedFile(
+        input.repoRoot,
+        rootRelativePath,
+        state,
+    );
+    if (!rootRead.ok) {
+        throw new Error(
+            `Unable to read root instruction file ${rootRelativePath}: ${rootRead.status}`,
+        );
+    }
+
+    // Ensure relative() style identity for stack membership
+    const rootKey = rootRelativePath;
+    const expanded = await expandContent(
+        input.repoRoot,
+        rootKey,
+        rootRead.content,
+        0,
+        [rootKey],
+        [rootKey],
+        state,
+    );
+
+    return {
+        root: rootKey,
+        content: expanded.content,
+        orderedSegments: expanded.segments,
+        edges: state.edges,
+        expansionDiagnostics: state.diagnostics,
+    };
+}

--- a/packages/core/src/lib/instruction-import-expand.ts
+++ b/packages/core/src/lib/instruction-import-expand.ts
@@ -378,7 +378,8 @@ class ExpansionSession {
 
     recordEdge(edge: ImportEdge): void {
         this.edges.push(edge);
-        if (edge.status === "resolved" || !edge.ruleId) {
+        // Failures always carry ruleId; resolved edges do not.
+        if (!edge.ruleId) {
             return;
         }
         this.diagnostics.push({


### PR DESCRIPTION
## Summary

Implements #1102 (first ready child of epic #1042): a pure Claude `@` import expander that builds an ordered `EffectiveDocument` with source map and safety diagnostics.

- New `buildEffectiveDocument` in `@lousy-agents/core/lib/instruction-import-expand`
- Doctor-aligned hard-import token recognition (line-start `@path` with `/`), skipping fenced/inline code
- Importer-relative resolution with root-bounded FS reuse (`readTextWithinRoot`, `statWithinRoot`, symlink rejection)
- Ordered splice at token position; branch-local failures; hop/cycle/unique-file/edge/emitted-byte limits
- **Not** wired into `analyze-instruction-quality` yet (Task 2 / #1103)

Fixes #1102

Parent epic: #1042

## Acceptance criteria → evidence

| Criterion | Evidence |
| --- | --- |
| Happy single import ordered splice | `instruction-import-expand.test.ts` single valid relative import |
| Depth 4 ok / depth 5 diagnostic | nested imports within depth limit test |
| Direct + indirect cycle | cycle describe blocks |
| Missing target | unresolved test |
| Symlink reject | symlink test (`skipIf` win32) |
| Path escape | escape test |
| Code-span / fenced `@` ignored | code exclusion tests |
| Double import positions | dual-import test |
| Absolute / `~/` reject | absolute + home tests |
| Branch-local failure | bad+good import in same file |
| Importer-dir relative resolution | nested importer directory test |
| Markdown links never imports | markdown link test |
| No quality analysis change | only new lib files; `analyze-instruction-quality` untouched |

## Red → green

- Red: missing module `./instruction-import-expand.js`
- Green: 15/15 expander tests pass; full `mise run ci` green (2002 unit + 67 integration)

## Validation

```bash
npm test -- packages/core/src/lib/instruction-import-expand.test.ts
npx biome check packages/core/src/lib/instruction-import-expand.ts packages/core/src/lib/instruction-import-expand.test.ts
mise run ci
```

## Agent workflow

- Single implementer → reviewer cycle (PASS)
- Correctness-review last pass: no required findings (optional hardening noted on issue)

## Test plan

- [x] Unit tests for expander safety and splice semantics
- [x] `mise run ci`
- [ ] CI on PR
- [ ] Follow-up #1103 wires expander into instruction quality (Coach A1)