### PR TITLE
docs(doctor): add customer-facing doctor command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ AI coding assistants work best when given clear constraints. Without structure, 
 - **[`init`](docs/init.md)** - Scaffold new projects with testing, linting, and Copilot configuration
 - **[`new`](docs/new.md)** - Create new resources like custom GitHub Copilot agents
 - **[`lint`](docs/lint.md)** - Validate skills, agents, hook configurations, and instruction files
+- **[`doctor`](docs/doctor.md)** - Inventory multi-harness agentic config, classify composition archetype, and evaluate preconditions
 - **[`copilot-setup`](docs/copilot-setup.md)** - Generate GitHub Actions workflows for Copilot environment setup
 - **[`init-hooks`](docs/lessons.md#init-hooks)** - Wire Claude Code hooks for lesson injection and capture
 
@@ -167,6 +168,7 @@ For detailed documentation on each command, see:
 - **[`init` command](docs/init.md)** - Scaffold new projects
 - **[`new` command](docs/new.md)** - Create new resources
 - **[`lint` command](docs/lint.md)** - Validate skills, agents, hook configurations, and instruction files
+- **[`doctor` command](docs/doctor.md)** - Diagnose multi-harness agentic configuration
 - **[`copilot-setup` command](docs/copilot-setup.md)** - Generate Copilot workflows
 - **[`init-hooks` command](docs/lessons.md#init-hooks)** - Wire Claude Code hooks for agent lessons
 - **[MCP Server](docs/mcp-server.md)** - AI assistant integration
@@ -195,6 +197,13 @@ npx @lousy-agents/cli copilot-setup
 
 ```bash
 npx @lousy-agents/cli lint
+```
+
+**Diagnose multi-harness agentic configuration:**
+
+```bash
+npx @lousy-agents/cli doctor
+npx @lousy-agents/cli doctor --format json --ci
 ```
 
 ## Contributing
@@ -226,6 +235,7 @@ Use the root install to work on all workspace packages together. The root `npm r
 | MCP server package | ✅ Complete |
 | Claude Code web environment setup | ✅ Complete |
 | Agent lesson system (context injection & capture) | ✅ Complete |
+| Multi-harness configuration doctor (inventory, edges, archetype, CI JSON) | ✅ Complete |
 
 ## Documentation
 
@@ -233,10 +243,12 @@ Use the root install to work on all workspace packages together. The root `npm r
 - **[Then `copilot-setup`](docs/copilot-setup.md)** - Generate workflow setup for existing repositories
 - **[`new` Command](docs/new.md)** - Create new resources after your scaffold is in place
 - **[`lint` Command](docs/lint.md)** - Validate skills, agents, hook configurations, and instruction files
+- **[`doctor` Command](docs/doctor.md)** - Diagnose multi-harness agentic configuration and composition
 - **[Agent Lessons](docs/lessons.md)** - Accumulate durable knowledge across Claude Code sessions
 - **[MCP Server](docs/mcp-server.md)** - Configure the separately published `@lousy-agents/mcp` package
-- **[agent-shell](packages/agent-shell/README.md)** - Add npm script execution telemetry
+- **[agent-shell](packages/agent-shell/README.md)** - Add npm script telemetry
 - **[@lousy-agents/lint API](packages/lint/README.md)** - Programmatic lint API for your own tools
+- **[@lousy-agents/agentic-doctor](packages/doctor/README.md)** - Doctor package landing page
 
 ## Reference Examples
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Use the root install to work on all workspace packages together. The root `npm r
 | MCP server package | ✅ Complete |
 | Claude Code web environment setup | ✅ Complete |
 | Agent lesson system (context injection & capture) | ✅ Complete |
-| Multi-harness configuration doctor (inventory, edges, archetype, CI JSON) | ✅ Complete |
+| Multi-harness configuration doctor (inventory, edges, archetype, CI JSON) | ✅ Shipped (spine; intent/capability gates and some harness depth still Partial) |
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Recommended reading order for new users:
 2. [init](init.md) — scaffold your first project
 3. [copilot-setup](copilot-setup.md) — add GitHub Copilot environment setup to an existing repository
 4. [new](new.md) and [lint](lint.md) — extend and validate your project scaffolding
-5. [doctor](doctor.md) — inventory multi-harness composition and gate known preconditions
+5. [doctor](doctor.md) — inventory multi-harness composition and evaluate known preconditions
 6. [MCP Server](mcp-server.md) — add the separately published `@lousy-agents/mcp` package if you want MCP integration
 
 ## Command Reference

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,12 @@ Internal product docs (PRD, harness capability matrix): **[docs/product/](produc
   - Multiple output formats (human, JSON, reviewdog)
   - CI integration
 
+- **[`doctor` Command](doctor.md)** - Diagnose multi-harness agentic configuration
+  - Inventory constructs and composition edges across harnesses
+  - Archetype classification (pure, hybrid, sprawl, and related labels)
+  - Criteria findings with CI-friendly JSON output
+  - Declared intent via `.agentic-doctor/intent.json`
+
 - **[`copilot-setup` Command](copilot-setup.md)** - Generate GitHub Actions workflows for Copilot environment setup
   - Environment detection
   - Workflow analysis and merging
@@ -38,6 +44,8 @@ Internal product docs (PRD, harness capability matrix): **[docs/product/](produc
   - VS Code configuration
   - Usage examples
 
+- **[Agent Lessons](lessons.md)** - Durable lesson capture and injection for Claude Code sessions
+
 ## Getting Started
 
 If you're new to Lousy Agents, start with the main [README](../README.md) for the package overview and quick start.
@@ -48,7 +56,8 @@ Recommended reading order for new users:
 2. [init](init.md) — scaffold your first project
 3. [copilot-setup](copilot-setup.md) — add GitHub Copilot environment setup to an existing repository
 4. [new](new.md) and [lint](lint.md) — extend and validate your project scaffolding
-5. [MCP Server](mcp-server.md) — add the separately published `@lousy-agents/mcp` package if you want MCP integration
+5. [doctor](doctor.md) — inventory multi-harness composition and gate known preconditions
+6. [MCP Server](mcp-server.md) — add the separately published `@lousy-agents/mcp` package if you want MCP integration
 
 ## Command Reference
 
@@ -91,6 +100,16 @@ The `copilot-setup` command analyzes your project and generates GitHub Actions w
 - Version file support
 - Generated workflow examples
 - Copilot PR review ruleset creation (with GHAS-aware code scanning)
+
+### `doctor`
+
+The `doctor` command inventories agentic constructs across coding-agent harnesses, classifies composition archetype, and evaluates known preconditions. See the [complete doctor documentation](doctor.md) for:
+
+- Inventory and composition edges (including JSON `inventory[]` / `edges[]`)
+- Archetype labels and dominance scoring
+- Criteria catalog and blocking exit rules
+- Declared intent (`.agentic-doctor/intent.json`)
+- CI usage with `--format json --ci`
 
 ### MCP Server
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -132,16 +132,18 @@ Advisories never fail the process on their own. Medium defects (for example miss
 
 | Criterion ID | Harness | Severity | Classification | Category | What it means |
 | ------------ | ------- | -------- | -------------- | -------- | ------------- |
-| `missing-copilot-instructions` | copilot | critical | defect | missing-required | `.github/copilot-instructions.md` is missing. Copilot has no workspace instruction entry point. |
-| `missing-claude-md` | claude | high | defect | missing-required | Neither `CLAUDE.md` nor `.claude/` is present for Claude Code. |
-| `missing-agents-md` | codex | high | defect | missing-required | Neither `AGENTS.md` nor `AGENTS.override.md` is present for Codex. |
-| `malformed-claude-import` | claude | high | defect | malformed-reference | A Claude `@path` hard-import points at a missing file or escapes the repo root. |
-| `cross-harness-drift` | all | high | advisory | drift | Archetype is `accidental-sprawl`: multiple harnesses with no cross-harness references. |
+| `missing-copilot-instructions` | copilot | critical | defect | missing-required | `.github/copilot-instructions.md` is missing while Copilot constructs are present (for example `.github/instructions/`). Blocks CI. |
+| `missing-claude-md` | claude | high | defect | missing-required | Neither `CLAUDE.md` nor `.claude/` is present while the Claude harness is attributed. In practice Claude is usually detected only via those paths, so this finding is rare. |
+| `missing-agents-md` | codex | high | defect | missing-required | Neither `AGENTS.md` nor `AGENTS.override.md` is present while Codex is attributed (for example via `.agents/skills/` or `.codex/`). Blocks CI. |
+| `malformed-claude-import` | claude | high | defect | malformed-reference | A Claude `@path` hard-import is malformed (missing target or path traversal). Blocks CI. |
+| `cross-harness-drift` | all | high | advisory | drift | Archetype is `accidental-sprawl`: multiple harnesses with no cross-harness references. Does not block CI. |
 | `wrong-direction-copilot-imports-claude` | copilot | medium | advisory | wrong-direction | A Copilot file uses Claude `@path` hard-import syntax toward a Claude file. Copilot does not process `@path` hard-imports. |
 | `wrong-direction-copilot-links-claude` | copilot | medium | advisory | wrong-direction | A Copilot file soft-references a Claude file (markdown link or frontmatter `see:` / `references:` / `requires:`). Copilot CLI does not follow those links. |
-| `missing-intent-artifact` | all | medium | defect | governance | Constructs exist but `.agentic-doctor/intent.json` is missing. Capability preconditions cannot be graded against declared intent. |
-| `missing-hermes-config` | hermes | medium | advisory | missing-required | Hermes footprint is present without `.hermes.md` or `HERMES.md`. |
-| `missing-crush-config` | crush | medium | advisory | missing-required | Crush footprint is present without `crush.json`. |
+| `missing-intent-artifact` | all | medium | defect | governance | Constructs exist but `.agentic-doctor/intent.json` is missing or invalid. Visible, non-blocking. |
+| `missing-hermes-config` | hermes | medium | advisory | missing-required | Hermes is attributed (for example via `SOUL.md`) without `.hermes.md` or `HERMES.md`. |
+| `missing-crush-config` | crush | medium | advisory | missing-required | Crush is attributed (for example via `.crush/`) without `crush.json`. |
+
+Missing-required checks run only when that harness already appears in the inventory. They fire when the harness was detected through a path other than the required entry file (Copilot via `.github/instructions/` is the common critical case).
 
 Use findings as referee input for humans and review agents. Feed durable ones into shared rules (`AGENTS.md`, `CLAUDE.md`) so the next wave of agents inherits the constraint.
 
@@ -181,12 +183,12 @@ Archetype: intentional-hybrid
 ✔ No findings.
 ```
 
-When findings exist, each line looks like:
+When findings exist (header plus severity-ordered lines):
 
 ```
-  [HIGH][defect] missing-claude-md: Claude Code requires CLAUDE.md or .claude/ directory to load project instructions.
-  [HIGH][advisory] cross-harness-drift: Multiple AI harnesses are configured but share no cross-harness references...
-  [MEDIUM][defect] missing-intent-artifact: No declared intent artifact found at .agentic-doctor/intent.json... [assumed intent]
+Findings (2):
+  [HIGH][advisory] cross-harness-drift: Multiple AI harnesses are configured but share no cross-harness references. This may indicate accidental configuration sprawl rather than intentional multi-harness setup.
+  [MEDIUM][defect] missing-intent-artifact: No declared intent artifact found at .agentic-doctor/intent.json. Without declared intent, the doctor cannot evaluate capability preconditions. [assumed intent]
 ```
 
 Tags are `[SEVERITY][classification]`. Findings with `assumedIntent: true` append `[assumed intent]`. Optional evidence citations print on the following line when present.
@@ -204,7 +206,7 @@ Tags are `[SEVERITY][classification]`. Findings with `assumedIntent: true` appen
 | `crossHarnessEdges` | number | Count of edges with `crossHarness: true` |
 | `inventory` | array | One entry per construct |
 | `edges` | array | Flattened composition edges |
-| `findings` | array | Criteria results (empty array when none). Omitted from evaluation when `--summary` is set. |
+| `findings` | array | Criteria results (empty array when none). Present only on full evaluate, not on `--summary`. |
 | `snapshotRef` | string? | Present when a local `wisdom/` graph is available |
 
 **Inventory item fields:** `id`, `path`, `harness`, `constructType`, `loadMechanism` (`referenced` \| `convention-loaded`), optional `serverName` / `transport` for `mcp-server` records.
@@ -217,7 +219,7 @@ Tags are `[SEVERITY][classification]`. Findings with `assumedIntent: true` appen
 | ----- | ---- | ----- |
 | `id` | string | Stable id, usually `criterionId:targetId` |
 | `criterionId` | string | Matches the criteria table |
-| `targetId` | string | What was graded (harness, path pair, or `all:intent`) |
+| `targetId` | string | What was graded: `all:intent`, `all:<archetype>` (drift), `harness:all`, or a harness pair |
 | `severity` | `critical` \| `high` \| `medium` \| `low` \| `info` | Ordering key in human output |
 | `category` | string | `missing-required`, `malformed-reference`, `wrong-direction`, `drift`, `governance`, or `composition-style` |
 | `classification` | `defect` \| `advisory` \| `info` | Only `defect` can block CI when severity is critical/high |
@@ -234,20 +236,26 @@ Reviewer agents can filter without re-scanning source:
 - Blocking gate set: `findings.filter(f => (f.severity === "critical" || f.severity === "high") && f.classification === "defect")`
 - Drift signal: `archetype`, `crossHarnessEdges`, and advisories with `criterionId === "cross-harness-drift"`
 
-Example fragment:
+Example fragment from an `accidental-sprawl` repo (no cross-harness edges, no intent file). High advisory does not fail CI; medium defect does not fail CI either:
 
 ```json
 {
-  "archetype": "intentional-hybrid",
-  "dominanceScore": 0.41,
-  "totalRecords": 59,
+  "archetype": "accidental-sprawl",
+  "dominanceScore": 0.5,
+  "totalRecords": 2,
   "harnessBreakdown": [
-    { "harness": "claude", "count": 26 },
-    { "harness": "codex", "count": 23 },
-    { "harness": "copilot", "count": 8 }
+    { "harness": "claude", "count": 1 },
+    { "harness": "copilot", "count": 1 }
   ],
-  "crossHarnessEdges": 1,
+  "crossHarnessEdges": 0,
   "inventory": [
+    {
+      "id": "copilot:.github/copilot-instructions.md",
+      "path": ".github/copilot-instructions.md",
+      "harness": "copilot",
+      "constructType": "instruction",
+      "loadMechanism": "convention-loaded"
+    },
     {
       "id": "claude:CLAUDE.md",
       "path": "CLAUDE.md",
@@ -256,15 +264,7 @@ Example fragment:
       "loadMechanism": "convention-loaded"
     }
   ],
-  "edges": [
-    {
-      "from": "CLAUDE.md",
-      "to": ".github/copilot-instructions.md",
-      "type": "hard-import",
-      "malformed": false,
-      "crossHarness": true
-    }
-  ],
+  "edges": [],
   "findings": [
     {
       "id": "missing-intent-artifact:all:intent",
@@ -278,9 +278,9 @@ Example fragment:
       "description": "No declared intent artifact found at .agentic-doctor/intent.json. Without declared intent, the doctor cannot evaluate capability preconditions."
     },
     {
-      "id": "cross-harness-drift:all:archetype",
+      "id": "cross-harness-drift:all:accidental-sprawl",
       "criterionId": "cross-harness-drift",
-      "targetId": "all:archetype",
+      "targetId": "all:accidental-sprawl",
       "severity": "high",
       "category": "drift",
       "classification": "advisory",
@@ -345,12 +345,14 @@ Interactive prompts on a TTY do not write this file for you. Create or update it
 | `0` | No blocking findings, or `--summary` (no evaluate) |
 | `1` | At least one critical or high **defect** on a full evaluate |
 
-Gating step (fails the job on blocking defects, keeps the report):
+Gating step (fails the job on blocking defects, keeps the report). Redirect does not hide doctor's exit code:
 
 ```yaml
 - name: Agentic configuration doctor
   run: npx @lousy-agents/cli doctor --format json --ci > doctor-report.json
 ```
+
+Example: a repo with Copilot instruction fragments under `.github/instructions/` but no `.github/copilot-instructions.md` exits `1` on full evaluate (`missing-copilot-instructions` is a critical defect). The same repo with `--summary` still exits `0`.
 
 Non-gating composition snapshot for PR artifacts or fleet baselines (always exit `0` from doctor):
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -8,7 +8,7 @@ Primary entry:
 npx @lousy-agents/cli doctor
 ```
 
-The same pipeline ships as `@lousy-agents/agentic-doctor` (bin: `agentic-doctor`) for library and standalone use. Most folks should start with the CLI.
+The implementation package is `@lousy-agents/agentic-doctor` (bin: `agentic-doctor`) inside this monorepo. It is **not** published to the public npm registry today. Use `@lousy-agents/cli doctor` for installable runs.
 
 ## Features
 
@@ -24,9 +24,9 @@ The same pipeline ships as `@lousy-agents/agentic-doctor` (bin: `agentic-doctor`
 1. Scan the current working directory for harness footprints and composition edges.
 2. Classify the repository archetype and compute harness dominance.
 3. Load optional declared intent from `.agentic-doctor/intent.json`.
-4. On an interactive TTY without `--ci`, ask short ambiguity questions when intent is missing (answers are not auto-written to disk).
+4. On an interactive TTY without `--ci`, optionally ask short ambiguity questions when intent is missing. Answers are only acknowledged (`Noted.`); they are **not** written to disk and **do not** change findings for that run. Doctor re-reads `.agentic-doctor/intent.json` afterward in case you created it in another terminal.
 5. Evaluate the criteria catalog against inventory, archetype, and intent.
-6. Print a human report or JSON. Exit `1` when any **critical** or **high** finding is classified as a **defect**.
+6. Print a human report or JSON. Exit `1` when any **critical** or **high** finding is classified as a **defect**. When the archetype is `none`, human mode prints that no agentic constructs were found and skips the full findings layout.
 
 This is a tight feedback loop for multi-agent work: inventory what the fleet can see, name the composition pattern, fail CI only on blocking defects.
 
@@ -35,7 +35,7 @@ This is a tight feedback loop for multi-agent work: inventory what the fleet can
 | Flag | Type | Default | Description |
 | ------ | ------ | --------- | ------------- |
 | `--summary` | boolean | `false` | Show archetype classification only. Skips criteria evaluation. JSON still includes `inventory`. |
-| `--format` | `human` \| `json` | `human` | Output format. |
+| `--format` | `human` \| `json` | `human` | Output format. Any value other than `json` is treated as `human`. |
 | `--ci` | boolean | `false` | Force non-interactive mode. Skips intent elicitation prompts. |
 
 ## Usage
@@ -328,7 +328,7 @@ Example:
 
 Commit the artifact when multi-harness posture is deliberate. That raises the floor for the next human or agent session: intent is shared law in git, not tribal knowledge in someone's terminal scrollback.
 
-Interactive prompts on a TTY do not write this file for you. Create or update it in source control yourself.
+Interactive prompts on a TTY do not write this file, and yes/no answers are not applied to the in-memory intent for that run. Create or update `.agentic-doctor/intent.json` in source control yourself, then re-run doctor.
 
 ## Exit codes and CI
 
@@ -370,7 +370,8 @@ After parallel agent runs on different directories, run full doctor before merge
 We are honest about what is Partial today:
 
 - Codex MCP servers declared only in TOML are not inventoried yet.
-- Intent write-back from interactive prompts is not implemented; commit `.agentic-doctor/intent.json` yourself.
+- Intent write-back from interactive prompts is not implemented; prompt answers are discarded after `Noted.` Commit `.agentic-doctor/intent.json` yourself.
+- `@lousy-agents/agentic-doctor` is not on the public npm registry yet; installable entry is `@lousy-agents/cli doctor`.
 - Shipped criteria do not yet gate on `desiredCapabilities` or `targetHarnesses` beyond presence of the intent file.
 - Human output summarizes findings; the full inventory and edge graph are JSON-only.
 - Harness depth is uneven. Copilot and Claude are strongest; other footprints are thinner.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,384 @@
+# `doctor` Command
+
+`doctor` inventories agentic constructs across coding-agent harnesses, classifies how the repository is composed, and evaluates known preconditions. Multi-harness repos often leave people in the dark about what each agent loads and how instruction files reference each other. We built doctor so that map is observable in one command, human or JSON.
+
+Primary entry:
+
+```bash
+npx @lousy-agents/cli doctor
+```
+
+The same pipeline ships as `@lousy-agents/agentic-doctor` (bin: `agentic-doctor`) for library and standalone use. Most folks should start with the CLI.
+
+## Features
+
+- **Multi-harness inventory**: Scans Claude Code, GitHub Copilot, Codex, and other known harness footprints for instructions, skills, agents, subagents, hooks, plugins, and MCP servers.
+- **Composition edges**: Records hard-imports (`@path`), soft-references (markdown links and frontmatter `see:` / `references:` / `requires:`), and Copilot `applyTo` glob-bindings, including a `crossHarness` flag when the target belongs to a different harness.
+- **Archetype classification**: Labels the repo as `pure`, `intentional-hybrid`, `canonical-contract`, `accidental-sprawl`, `none`, or `ambiguous` so fleet drift is visible without reading every config file.
+- **Criteria evaluation**: Grades missing required files, malformed references, wrong-direction cross-harness links, sprawl, and missing declared intent.
+- **Machine-readable JSON**: Emits the full inventory and edge graph for CI, reviewer agents, and handoff artifacts.
+- **Non-interactive CI mode**: `--ci` skips prompts so doctor is safe in pipelines.
+
+## How It Works
+
+1. Scan the current working directory for harness footprints and composition edges.
+2. Classify the repository archetype and compute harness dominance.
+3. Load optional declared intent from `.agentic-doctor/intent.json`.
+4. On an interactive TTY without `--ci`, ask short ambiguity questions when intent is missing (answers are not auto-written to disk).
+5. Evaluate the criteria catalog against inventory, archetype, and intent.
+6. Print a human report or JSON. Exit `1` when any **critical** or **high** finding is classified as a **defect**.
+
+This is a tight feedback loop for multi-agent work: inventory what the fleet can see, name the composition pattern, fail CI only on blocking defects.
+
+## Options
+
+| Flag | Type | Default | Description |
+| ------ | ------ | --------- | ------------- |
+| `--summary` | boolean | `false` | Show archetype classification only. Skips criteria evaluation. JSON still includes `inventory`. |
+| `--format` | `human` \| `json` | `human` | Output format. |
+| `--ci` | boolean | `false` | Force non-interactive mode. Skips intent elicitation prompts. |
+
+## Usage
+
+### Basic usage
+
+Run from your project root:
+
+```bash
+npx @lousy-agents/cli doctor
+```
+
+Human output opens with archetype, dominance score, harness breakdown, and optional cross-harness edge count, then lists findings ordered by severity.
+
+### Summary only
+
+```bash
+npx @lousy-agents/cli doctor --summary
+```
+
+Use this when you only need the composition label before a deeper pass. `--summary` skips criteria evaluation, so the process exit code stays `0` even when a full run would report blocking defects.
+
+### JSON for agents and automation
+
+```bash
+npx @lousy-agents/cli doctor --format json --ci
+```
+
+JSON is the surface for reviewer agents, fleet aggregation, and storing a composition snapshot next to a PR.
+
+### After parallel agent waves
+
+1. Run `npx @lousy-agents/cli doctor --format json --ci` as the composition referee (archetype, edges, blocking defects).
+2. Run `npx @lousy-agents/cli lint` for file-quality diagnostics on shared discovery paths.
+3. Promote durable defects into shared law (`AGENTS.md`, `CLAUDE.md`, `.agentic-doctor/intent.json`) so the next wave inherits the constraint.
+
+### Help
+
+```bash
+npx @lousy-agents/cli doctor --help
+```
+
+## What It Inventories
+
+Doctor attributes each construct to a harness (`claude`, `copilot`, `codex`, `antigravity`, `hermes`, `crush`, `pi`, or `shared`) and a construct type:
+
+| Construct type | Examples |
+| -------------- | -------- |
+| `instruction` | `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.md` |
+| `skill` | `.claude/skills/`, `.github/skills/`, `.agents/skills/`, `.pi/skills/` |
+| `agent` | `.github/agents/**/*.md`, `.claude/commands/` |
+| `subagent` | `.claude/agents/**/*.md` |
+| `hook` | `.claude/settings.json`, `.github/hooks/` |
+| `mcp-server` | One record per server declared in `.mcp.json` or `.vscode/mcp.json` |
+| `plugin` | Plugin manifests under known plugin roots |
+
+Paths come from the shared agentic location catalog in `@lousy-agents/core` (the same catalog [lint](lint.md) uses). Doctor may inventory constructs lint does not validate yet.
+
+**MCP notes:**
+
+- JSON sources are enumerated (for example `.mcp.json` attributed as `shared`, `.vscode/mcp.json` as `copilot`).
+- VS Code-style configs that use a top-level `servers` key are recognized.
+- Codex TOML `[mcp_servers.*]` in `.codex/config.toml` is not enumerated yet.
+
+**Filesystem notes:**
+
+- Doctor follows in-repo symlinks when inventorying instruction files (common when teams symlink `AGENTS.md`).
+- Symlinks that escape the repository root are rejected.
+- Lint skips symlinks by design. That difference is intentional.
+
+## Archetypes
+
+| Archetype | Meaning |
+| --------- | ------- |
+| `pure` | One non-shared harness dominates (share ≥ 80%) and there are no cross-harness edges. |
+| `intentional-hybrid` | Multiple harnesses are present and at least one non-malformed, non-glob cross-harness edge exists. |
+| `canonical-contract` | Only `shared` harness constructs were found (for example a shared contract file read by multiple tools). |
+| `accidental-sprawl` | Multiple harnesses are configured without cross-harness references. |
+| `none` | No agentic constructs found. |
+| `ambiguous` | Detection includes harnesses whose footprints still need verification, or the shape does not fit cleanly. |
+
+Dominance score is the top harness share of weighted inventory (records plus edges). Treat archetype as a fleet signal: after parallel agent runs, a flip from `intentional-hybrid` to `accidental-sprawl` means shared references were lost or never existed.
+
+## Criteria reference
+
+Findings carry `severity`, `classification` (`defect` \| `advisory` \| `info`), and a stable `criterionId`.
+
+**Blocking rule:** process exit code is `1` only when a finding is both:
+
+- `severity` of `critical` or `high`, and
+- `classification` of `defect`
+
+Advisories never fail the process on their own. Medium defects (for example missing intent) appear in the report but do not set exit code `1`.
+
+| Criterion ID | Harness | Severity | Classification | Category | What it means |
+| ------------ | ------- | -------- | -------------- | -------- | ------------- |
+| `missing-copilot-instructions` | copilot | critical | defect | missing-required | `.github/copilot-instructions.md` is missing. Copilot has no workspace instruction entry point. |
+| `missing-claude-md` | claude | high | defect | missing-required | Neither `CLAUDE.md` nor `.claude/` is present for Claude Code. |
+| `missing-agents-md` | codex | high | defect | missing-required | Neither `AGENTS.md` nor `AGENTS.override.md` is present for Codex. |
+| `malformed-claude-import` | claude | high | defect | malformed-reference | A Claude `@path` hard-import points at a missing file or escapes the repo root. |
+| `cross-harness-drift` | all | high | advisory | drift | Archetype is `accidental-sprawl`: multiple harnesses with no cross-harness references. |
+| `wrong-direction-copilot-imports-claude` | copilot | medium | advisory | wrong-direction | A Copilot file uses Claude `@path` hard-import syntax toward a Claude file. Copilot does not process `@path` hard-imports. |
+| `wrong-direction-copilot-links-claude` | copilot | medium | advisory | wrong-direction | A Copilot file soft-references a Claude file (markdown link or frontmatter `see:` / `references:` / `requires:`). Copilot CLI does not follow those links. |
+| `missing-intent-artifact` | all | medium | defect | governance | Constructs exist but `.agentic-doctor/intent.json` is missing. Capability preconditions cannot be graded against declared intent. |
+| `missing-hermes-config` | hermes | medium | advisory | missing-required | Hermes footprint is present without `.hermes.md` or `HERMES.md`. |
+| `missing-crush-config` | crush | medium | advisory | missing-required | Crush footprint is present without `crush.json`. |
+
+Use findings as referee input for humans and review agents. Feed durable ones into shared rules (`AGENTS.md`, `CLAUDE.md`) so the next wave of agents inherits the constraint.
+
+## Doctor vs lint
+
+Doctor and lint share the discovery catalog. They answer different questions:
+
+| Concern | doctor | lint |
+| ------- | ------ | ---- |
+| Question | What agentic surface exists, how does it compose, and which preconditions fail? | Are discovered construct files well-formed and high quality? |
+| When (typical) | First after parallel agent waves: composition referee before merge | Second: structural quality on the paths both tools share |
+| Output | Archetype, inventory, edges, criteria findings | Rule diagnostics with line numbers |
+| CI role | Composition and missing-required gates | Structural validation gates |
+| Symlinks | Follows in-repo targets | Skips symlinked targets |
+| Coverage | Broader inventory (plugins, multi-harness trees, MCP servers as inventory records) | Validates skills, agents, hooks, instructions by default; subagents and MCP are flag-only |
+
+See [lint](lint.md) for validation rules, rollout status, and flag-only targets. Doctor finds the map; lint grades file quality on the paths both tools share.
+
+## Output formats
+
+### Human (default)
+
+When there are no findings:
+
+```
+Archetype: intentional-hybrid
+  Multi-harness configuration with cross-harness references. Harnesses deliberately share context.
+  Dominance score: 41%
+  Total records: 59
+  Harness breakdown:
+    antigravity: 1
+    claude: 26
+    codex: 23
+    copilot: 8
+    shared: 1
+  Cross-harness edges: 1
+✔ No findings.
+```
+
+When findings exist, each line looks like:
+
+```
+  [HIGH][defect] missing-claude-md: Claude Code requires CLAUDE.md or .claude/ directory to load project instructions.
+  [HIGH][advisory] cross-harness-drift: Multiple AI harnesses are configured but share no cross-harness references...
+  [MEDIUM][defect] missing-intent-artifact: No declared intent artifact found at .agentic-doctor/intent.json... [assumed intent]
+```
+
+Tags are `[SEVERITY][classification]`. Findings with `assumedIntent: true` append `[assumed intent]`. Optional evidence citations print on the following line when present.
+
+### JSON
+
+`--format json` emits a Zod-validated report. Existing aggregate keys stay stable; `inventory` and `edges` are additive.
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `archetype` | string | One of the archetype values above |
+| `dominanceScore` | number | Top harness share, 0–1 |
+| `totalRecords` | number | Length of inventory |
+| `harnessBreakdown` | `{ harness, count }[]` | Sorted by harness name |
+| `crossHarnessEdges` | number | Count of edges with `crossHarness: true` |
+| `inventory` | array | One entry per construct |
+| `edges` | array | Flattened composition edges |
+| `findings` | array | Criteria results (empty array when none). Omitted from evaluation when `--summary` is set. |
+| `snapshotRef` | string? | Present when a local `wisdom/` graph is available |
+
+**Inventory item fields:** `id`, `path`, `harness`, `constructType`, `loadMechanism` (`referenced` \| `convention-loaded`), optional `serverName` / `transport` for `mcp-server` records.
+
+**Edge fields:** `from`, `to`, `type` (`hard-import` \| `soft-reference` \| `glob-binding`), `malformed`, optional `reason` (`missing-target` \| `path-traversal`), `crossHarness` (boolean; always set).
+
+**Finding fields** (full evaluate only):
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | string | Stable id, usually `criterionId:targetId` |
+| `criterionId` | string | Matches the criteria table |
+| `targetId` | string | What was graded (harness, path pair, or `all:intent`) |
+| `severity` | `critical` \| `high` \| `medium` \| `low` \| `info` | Ordering key in human output |
+| `category` | string | `missing-required`, `malformed-reference`, `wrong-direction`, `drift`, `governance`, or `composition-style` |
+| `classification` | `defect` \| `advisory` \| `info` | Only `defect` can block CI when severity is critical/high |
+| `intentGated` | boolean | Reserved for intent-gated checks (none active in the shipped catalog) |
+| `assumedIntent` | boolean | `true` when the finding assumes missing intent (for example `missing-intent-artifact`) |
+| `description` | string | Human-readable explanation |
+| `evidenceCitation` | object? | Optional `{ nodeId, sourceFile, lineRange?, snapshotRef? }` |
+| `snapshotRef` | string? | Optional evidence pin on the finding |
+
+`crossHarness` is `true` only when the edge is not malformed, type is not `glob-binding`, and the resolved target path maps to a known record on a different harness. The `crossHarnessEdges` count uses the same predicate.
+
+Reviewer agents can filter without re-scanning source:
+
+- Blocking gate set: `findings.filter(f => (f.severity === "critical" || f.severity === "high") && f.classification === "defect")`
+- Drift signal: `archetype`, `crossHarnessEdges`, and advisories with `criterionId === "cross-harness-drift"`
+
+Example fragment:
+
+```json
+{
+  "archetype": "intentional-hybrid",
+  "dominanceScore": 0.41,
+  "totalRecords": 59,
+  "harnessBreakdown": [
+    { "harness": "claude", "count": 26 },
+    { "harness": "codex", "count": 23 },
+    { "harness": "copilot", "count": 8 }
+  ],
+  "crossHarnessEdges": 1,
+  "inventory": [
+    {
+      "id": "claude:CLAUDE.md",
+      "path": "CLAUDE.md",
+      "harness": "claude",
+      "constructType": "instruction",
+      "loadMechanism": "convention-loaded"
+    }
+  ],
+  "edges": [
+    {
+      "from": "CLAUDE.md",
+      "to": ".github/copilot-instructions.md",
+      "type": "hard-import",
+      "malformed": false,
+      "crossHarness": true
+    }
+  ],
+  "findings": [
+    {
+      "id": "missing-intent-artifact:all:intent",
+      "criterionId": "missing-intent-artifact",
+      "targetId": "all:intent",
+      "severity": "medium",
+      "category": "governance",
+      "classification": "defect",
+      "intentGated": false,
+      "assumedIntent": true,
+      "description": "No declared intent artifact found at .agentic-doctor/intent.json. Without declared intent, the doctor cannot evaluate capability preconditions."
+    },
+    {
+      "id": "cross-harness-drift:all:archetype",
+      "criterionId": "cross-harness-drift",
+      "targetId": "all:archetype",
+      "severity": "high",
+      "category": "drift",
+      "classification": "advisory",
+      "intentGated": false,
+      "assumedIntent": false,
+      "description": "Multiple AI harnesses are configured but share no cross-harness references. This may indicate accidental configuration sprawl rather than intentional multi-harness setup."
+    }
+  ]
+}
+```
+
+With `--summary`, JSON includes archetype fields plus `inventory` only. It does not emit `edges` or `findings`, and it does not run criteria evaluation.
+
+## Declared intent
+
+Optional artifact path: `.agentic-doctor/intent.json`.
+
+**What the shipped evaluator does today:** if constructs exist and this file is missing or invalid, `missing-intent-artifact` fires as a **medium defect** (visible in the report, non-blocking for exit code). When the file is present and valid, that finding clears. The engine can run `intent.capabilityDeclared` checks, but **no shipped criterion uses that check method yet**, so `targetHarnesses` and `desiredCapabilities` do not change findings in the current catalog. Treat the file as version-controlled posture for humans, reviewer agents, and future capability gates.
+
+Schema fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `targetHarnesses` | string[] | Intended harnesses (`claude`, `copilot`, `codex`, `antigravity`, `hermes`, `crush`, `pi`, `shared`). Recorded posture; not read by shipped criteria. |
+| `desiredCapabilities` | string[] | Capability ids you claim. Reserved for intent-gated criteria; none active in the shipped catalog. |
+| `confirmedAnswers` | object | Free-form confirmed decisions (for example declared archetype rationale) |
+| `intentSource` | `interactive` \| `ci-assumed` \| `pre-committed` | How the artifact was produced |
+| `snapshotRef` | string? | Optional evidence snapshot pin |
+
+Known capability id attached as metadata on a shipped criterion (for documentation and future gates): `copilot-workspace-instructions` on `missing-copilot-instructions`. Do not invent fleet-only capability strings and expect doctor to grade them today.
+
+Example:
+
+```json
+{
+  "targetHarnesses": ["copilot", "claude", "codex"],
+  "desiredCapabilities": ["copilot-workspace-instructions"],
+  "confirmedAnswers": {
+    "archetype": "intentional-hybrid",
+    "rationale": "Copilot, Claude Code, and Codex are intentional. CLAUDE.md hard-imports shared Copilot instructions."
+  },
+  "intentSource": "pre-committed"
+}
+```
+
+Commit the artifact when multi-harness posture is deliberate. That raises the floor for the next human or agent session: intent is shared law in git, not tribal knowledge in someone's terminal scrollback.
+
+Interactive prompts on a TTY do not write this file for you. Create or update it in source control yourself.
+
+## Exit codes and CI
+
+### CI contract
+
+- Full evaluate (`doctor` or `doctor --format json`, without `--summary`) sets exit code `1` only when `hasBlockingFindings` is true: at least one finding with `severity` of `critical` or `high` **and** `classification` of `defect`.
+- High **advisories** (for example `cross-harness-drift`) never fail the process on their own.
+- Medium **defects** (for example `missing-intent-artifact`) appear in the report and do not set exit code `1`.
+- `--summary` skips evaluate. Exit code stays `0`. Use it for composition snapshots, not as a merge gate.
+- Prefer writing JSON to a file in the same step that gates, so the step exit code is doctor's exit code (avoid bare pipes that drop status unless `pipefail` is on).
+
+| Exit code | When |
+| --------- | ---- |
+| `0` | No blocking findings, or `--summary` (no evaluate) |
+| `1` | At least one critical or high **defect** on a full evaluate |
+
+Gating step (fails the job on blocking defects, keeps the report):
+
+```yaml
+- name: Agentic configuration doctor
+  run: npx @lousy-agents/cli doctor --format json --ci > doctor-report.json
+```
+
+Non-gating composition snapshot for PR artifacts or fleet baselines (always exit `0` from doctor):
+
+```yaml
+- name: Doctor summary artifact
+  run: npx @lousy-agents/cli doctor --summary --format json --ci > doctor-summary.json
+```
+
+Fleet pattern without a productized aggregator: store `doctor-report.json` or `doctor-summary.json` per PR, then diff `archetype`, `crossHarnessEdges`, and blocking `criterionId` values over time.
+
+After parallel agent runs on different directories, run full doctor before merge. Use archetype, `crossHarnessEdges`, and blocking defects as an independent referee beside tests and human review.
+
+## Limits (work in progress)
+
+We are honest about what is Partial today:
+
+- Codex MCP servers declared only in TOML are not inventoried yet.
+- Intent write-back from interactive prompts is not implemented; commit `.agentic-doctor/intent.json` yourself.
+- Shipped criteria do not yet gate on `desiredCapabilities` or `targetHarnesses` beyond presence of the intent file.
+- Human output summarizes findings; the full inventory and edge graph are JSON-only.
+- Harness depth is uneven. Copilot and Claude are strongest; other footprints are thinner.
+- Optional `snapshotRef` requires a local `wisdom/` graph. Runs succeed without it.
+- Lint does not validate every construct doctor can inventory. See [lint rollout status](lint.md#rollout-status).
+
+## Related docs
+
+- [lint](lint.md): shared catalog, construct validation, flag-only subagents and MCP
+- [Agent Lessons](lessons.md): durable session knowledge under `.lousy-agents/lessons/`
+- [MCP Server](mcp-server.md): `@lousy-agents/mcp` tools for assistants
+- [agent-shell](../packages/agent-shell/README.md): npm script telemetry and policy hooks
+- [@lousy-agents/agentic-doctor](../packages/doctor/README.md): package landing page

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -42,7 +42,7 @@ New construct kinds ship **flag-only first**, then get promoted to default-on on
 
 ### Lint vs doctor
 
-Lint and doctor share the same catalog. Doctor may inventory additional constructs the linter does not validate (plugins, multi-harness instruction trees, and other catalog entries with no lint target).
+Lint and doctor share the same catalog. Doctor may inventory additional constructs the linter does not validate (plugins, multi-harness instruction trees, and other catalog entries with no lint target). Full doctor command reference: [`doctor.md`](doctor.md).
 
 Intentional policy differences (not catalog drift):
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,10 @@ npx @lousy-agents/cli new
 
 # Validate skills, agents, and instruction files
 npx @lousy-agents/cli lint
+
+# Diagnose multi-harness agentic configuration
+npx @lousy-agents/cli doctor
+npx @lousy-agents/cli doctor --format json --ci
 ```
 
 ## Documentation
@@ -29,6 +33,7 @@ npx @lousy-agents/cli lint
 - `init` command: [`docs/init.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/init.md)
 - `new` command: [`docs/new.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/new.md)
 - `lint` command: [`docs/lint.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/lint.md)
+- `doctor` command: [`docs/doctor.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/doctor.md)
 - `copilot-setup` command: [`docs/copilot-setup.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/copilot-setup.md)
 
 ## Reference Examples

--- a/packages/doctor/README.md
+++ b/packages/doctor/README.md
@@ -2,26 +2,23 @@
 
 Agentic configuration doctor: inventory multi-harness constructs, classify repository archetype, and evaluate known preconditions.
 
-Most users should run doctor through the CLI:
+## Installable entry (recommended)
+
+This package name is **not published to the public npm registry** today. Run doctor through the published CLI:
 
 ```bash
 npx @lousy-agents/cli doctor
 npx @lousy-agents/cli doctor --format json --ci
 ```
 
-This package also ships the `agentic-doctor` binary and a programmatic API for embedding the same pipeline.
+## Monorepo / library use
+
+Inside this repository (or a workspace that depends on the local package), the library export and `agentic-doctor` bin are available after build:
 
 ```bash
-npx -y -p @lousy-agents/agentic-doctor agentic-doctor --format json --ci
+npm run build --workspace=packages/doctor
+node packages/doctor/dist/cli/index.js --format json --ci
 ```
-
-## Documentation
-
-- Full command reference: [`docs/doctor.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/doctor.md)
-- Project overview: [README](https://github.com/zpratt/lousy-agents#readme)
-- Lint vs doctor discovery: [`docs/lint.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/lint.md)
-
-## Programmatic use
 
 ```ts
 import {
@@ -29,16 +26,30 @@ import {
   classifyArchetype,
   evaluate,
   CRITERIA,
+  formatSummary,
   toJson,
+  hasBlockingFindings,
+  readIntentArtifact,
 } from "@lousy-agents/agentic-doctor";
 
-const records = await scanRepository(process.cwd());
+const repoPath = process.cwd();
+const records = await scanRepository(repoPath);
 const classification = classifyArchetype(records);
+const summary = formatSummary(records, classification);
+const intentResult = await readIntentArtifact(repoPath);
 const findings = evaluate(CRITERIA, {
   records,
   classification,
-  intent: null,
+  intent: intentResult.found ? intentResult.artifact : null,
 });
+const report = toJson(summary, findings, records);
+if (hasBlockingFindings(findings)) {
+  process.exitCode = 1;
+}
 ```
 
-See [`docs/doctor.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/doctor.md) for flags, JSON shape, criteria, exit codes, and CI examples.
+## Documentation
+
+- Full command reference: [`docs/doctor.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/doctor.md)
+- Project overview: [README](https://github.com/zpratt/lousy-agents#readme)
+- Lint vs doctor discovery: [`docs/lint.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/lint.md)

--- a/packages/doctor/README.md
+++ b/packages/doctor/README.md
@@ -1,0 +1,44 @@
+# @lousy-agents/agentic-doctor
+
+Agentic configuration doctor: inventory multi-harness constructs, classify repository archetype, and evaluate known preconditions.
+
+Most users should run doctor through the CLI:
+
+```bash
+npx @lousy-agents/cli doctor
+npx @lousy-agents/cli doctor --format json --ci
+```
+
+This package also ships the `agentic-doctor` binary and a programmatic API for embedding the same pipeline.
+
+```bash
+npx -y -p @lousy-agents/agentic-doctor agentic-doctor --format json --ci
+```
+
+## Documentation
+
+- Full command reference: [`docs/doctor.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/doctor.md)
+- Project overview: [README](https://github.com/zpratt/lousy-agents#readme)
+- Lint vs doctor discovery: [`docs/lint.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/lint.md)
+
+## Programmatic use
+
+```ts
+import {
+  scanRepository,
+  classifyArchetype,
+  evaluate,
+  CRITERIA,
+  toJson,
+} from "@lousy-agents/agentic-doctor";
+
+const records = await scanRepository(process.cwd());
+const classification = classifyArchetype(records);
+const findings = evaluate(CRITERIA, {
+  records,
+  classification,
+  intent: null,
+});
+```
+
+See [`docs/doctor.md`](https://github.com/zpratt/lousy-agents/blob/main/docs/doctor.md) for flags, JSON shape, criteria, exit codes, and CI examples.


### PR DESCRIPTION
## Summary

- Add `docs/doctor.md`: multi-harness inventory, composition edges, archetypes, full criteria table, JSON findings contract, declared intent honesty, and CI exit rules for `npx @lousy-agents/cli doctor`
- Add thin `packages/doctor/README.md` for `@lousy-agents/agentic-doctor` (monorepo/library; not on public npm yet)
- Wire hubs: root README (Features, Usage, Roadmap, Documentation), `docs/README.md`, `packages/cli/README.md`, and reverse link from `docs/lint.md`

## Test plan

- [x] Open `docs/doctor.md` and confirm flags match `npx @lousy-agents/cli doctor --help`
- [x] Spot-check criteria table against `packages/doctor/src/use-cases/criteria.ts`
- [x] Confirm blocking exit rule matches `hasBlockingFindings` (critical/high **defect** only; `--summary` does not evaluate)
- [x] Confirm hub links resolve: root README, `docs/README.md`, `packages/cli/README.md`, `packages/doctor/README.md`
- [x] Confirm `docs/lint.md` links to `doctor.md`