### PR TITLE
fix(deps): clear Dependabot alerts and unblock Biome 2.5.7

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,12 +74,12 @@
                     "context7": {
                         "type": "stdio",
                         "command": "npx",
-                        "args": ["@upstash/context7-mcp"]
+                        "args": ["@upstash/context7-mcp@4.0.0"]
                     },
                     "sequential-thinking": {
                         "command": "npx",
                         "args": [
-                            "@modelcontextprotocol/server-sequential-thinking"
+                            "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
                         ]
                     }
                 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,5 +7,5 @@ mise install --yes --locked
 
 npm ci
 
-claude mcp add --transport stdio context7 npx @upstash/context7-mcp
-claude mcp add --transport stdio sequential-thinking npx @modelcontextprotocol/server-sequential-thinking
+claude mcp add --transport stdio context7 npx @upstash/context7-mcp@4.0.0
+claude mcp add --transport stdio sequential-thinking npx @modelcontextprotocol/server-sequential-thinking@2026.7.4

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/docs/init.md
+++ b/docs/init.md
@@ -38,7 +38,8 @@ Scaffolds new projects with everything needed for effective AI-assisted developm
 - CI workflow with lint, test, and build jobs
 - Dev Container setup with:
   - Pre-installed tools (GitHub CLI, actionlint, shellcheck, yamllint)
-  - MCP servers pre-cached (context7-mcp, sequential-thinking)
+  - MCP servers pre-cached (sequential-thinking); context7 is invoked via version-pinned `npx` (not a package.json dependency)
+  - Residual risk: `@upstash/context7-mcp@4.0.0` still pulls `@hono/node-server@1.x` at runtime until upstream publishes a fixed release — it is kept out of lockfiles intentionally
   - Docker-outside-of-docker support
 - EditorConfig and Node.js version management
 
@@ -75,7 +76,8 @@ Scaffolds new projects with everything needed for effective AI-assisted developm
   - MCP servers configuration (context7, sequential-thinking, lousy-agents)
 - Dev Container setup with:
   - Pre-installed tools (GitHub CLI, actionlint, shellcheck, yamllint)
-  - MCP servers pre-cached (context7-mcp, sequential-thinking)
+  - MCP servers pre-cached (sequential-thinking); context7 is invoked via version-pinned `npx` (not a package.json dependency)
+  - Residual risk: `@upstash/context7-mcp@4.0.0` still pulls `@hono/node-server@1.x` at runtime until upstream publishes a fixed release — it is kept out of lockfiles intentionally
   - Docker-outside-of-docker support
   - Port forwarding for API server (3000) and PostgreSQL (5432)
 - EditorConfig and Node.js version management

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,13 @@
                 "packages/doctor"
             ],
             "devDependencies": {
-                "@biomejs/biome": "2.5.3",
+                "@biomejs/biome": "2.5.7",
                 "@modelcontextprotocol/server-sequential-thinking": "2026.7.4",
                 "@rspack/cli": "2.1.8",
                 "@rspack/core": "2.1.8",
                 "@types/chance": "1.1.8",
                 "@types/mdast": "4.0.4",
                 "@types/node": "25.9.5",
-                "@upstash/context7-mcp": "4.0.0",
                 "chance": "1.1.13",
                 "dependency-cruiser": "18.1.1",
                 "fast-check": "4.9.0",
@@ -44,9 +43,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-            "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+            "integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -60,20 +59,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.5.3",
-                "@biomejs/cli-darwin-x64": "2.5.3",
-                "@biomejs/cli-linux-arm64": "2.5.3",
-                "@biomejs/cli-linux-arm64-musl": "2.5.3",
-                "@biomejs/cli-linux-x64": "2.5.3",
-                "@biomejs/cli-linux-x64-musl": "2.5.3",
-                "@biomejs/cli-win32-arm64": "2.5.3",
-                "@biomejs/cli-win32-x64": "2.5.3"
+                "@biomejs/cli-darwin-arm64": "2.5.7",
+                "@biomejs/cli-darwin-x64": "2.5.7",
+                "@biomejs/cli-linux-arm64": "2.5.7",
+                "@biomejs/cli-linux-arm64-musl": "2.5.7",
+                "@biomejs/cli-linux-x64": "2.5.7",
+                "@biomejs/cli-linux-x64-musl": "2.5.7",
+                "@biomejs/cli-win32-arm64": "2.5.7",
+                "@biomejs/cli-win32-x64": "2.5.7"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-            "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+            "integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
             "cpu": [
                 "arm64"
             ],
@@ -88,9 +87,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-            "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+            "integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
             "cpu": [
                 "x64"
             ],
@@ -105,13 +104,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-            "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+            "integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -122,13 +124,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-            "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+            "integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -139,13 +144,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-            "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+            "integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -156,13 +164,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-            "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+            "integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -173,9 +184,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-            "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+            "integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
             "cpu": [
                 "arm64"
             ],
@@ -190,9 +201,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-            "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+            "integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
             "cpu": [
                 "x64"
             ],
@@ -842,54 +853,6 @@
             "resolved": "packages/mcp",
             "link": true
         },
-        "node_modules/@modelcontextprotocol/core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
-            "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "zod": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@modelcontextprotocol/node": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
-            "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@hono/node-server": "^1.19.9"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "peerDependencies": {
-                "@modelcontextprotocol/server": "^2.0.0",
-                "hono": "^4.11.4"
-            },
-            "peerDependenciesMeta": {
-                "hono": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@modelcontextprotocol/node/node_modules/@hono/node-server": {
-            "version": "1.19.17",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-            "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.14.1"
-            },
-            "peerDependencies": {
-                "hono": "^4"
-            }
-        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -928,20 +891,6 @@
                 "zod": {
                     "optional": false
                 }
-            }
-        },
-        "node_modules/@modelcontextprotocol/server": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
-            "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@modelcontextprotocol/core": "2.0.0",
-                "zod": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=20"
             }
         },
         "node_modules/@modelcontextprotocol/server-sequential-thinking": {
@@ -1905,17 +1854,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@types/body-parser": {
-            "version": "1.19.6",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1933,16 +1871,6 @@
             "integrity": "sha512-isycXjm4a88/zl3n9lfgMcEClR9wUi+m72lkE9MvEbkgZDQrKzolWbonBiUqDNAJFIwO9GKjzmJFq79qtKVTAQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/connect": {
-            "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/debug": {
             "version": "4.1.13",
@@ -1990,38 +1918,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/express": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
-            "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^5.0.0",
-                "@types/serve-static": "^2"
-            }
-        },
-        "node_modules/@types/express-serve-static-core": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
-            "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "node_modules/@types/http-errors": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2053,41 +1949,6 @@
             "integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/range-parser": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/send": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-errors": "*",
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/ssh2": {
             "version": "1.15.5",
@@ -2470,29 +2331,6 @@
             ],
             "engines": {
                 "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@upstash/context7-mcp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@upstash/context7-mcp/-/context7-mcp-4.0.0.tgz",
-            "integrity": "sha512-7TlB85xbKbSHzI4G//3Qm+g8ryW11WZLd7PAOFdH5IxzAv1Yk+lcSBgDM4lDoYHXltzSwK7iUciiFNbFj7493Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@modelcontextprotocol/node": "2.0.0",
-                "@modelcontextprotocol/server": "2.0.0",
-                "@types/express": "^5.0.4",
-                "commander": "^13.1.0",
-                "express": "^5.1.0",
-                "jose": "^6.2.3",
-                "undici": "^7.0.0",
-                "zod": "^4.4.3"
-            },
-            "bin": {
-                "context7-mcp": "dist/index.js"
-            },
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/@vitest/expect": {
@@ -3376,16 +3214,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/commander": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/compress-commons": {
             "version": "6.0.2",
@@ -5814,9 +5642,9 @@
             "optional": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -7301,16 +7129,6 @@
                 "@typescript/typescript-sunos-x64": "7.0.2",
                 "@typescript/typescript-win32-arm64": "7.0.2",
                 "@typescript/typescript-win32-x64": "7.0.2"
-            }
-        },
-        "node_modules/undici": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -45,14 +45,13 @@
         "lint:yaml": "yamllint ."
     },
     "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.7",
         "@modelcontextprotocol/server-sequential-thinking": "2026.7.4",
         "@rspack/cli": "2.1.8",
         "@rspack/core": "2.1.8",
         "@types/chance": "1.1.8",
         "@types/mdast": "4.0.4",
         "@types/node": "25.9.5",
-        "@upstash/context7-mcp": "4.0.0",
         "chance": "1.1.13",
         "dependency-cruiser": "18.1.1",
         "fast-check": "4.9.0",

--- a/packages/agent-shell/tests/integration/log-query.test.ts
+++ b/packages/agent-shell/tests/integration/log-query.test.ts
@@ -9,6 +9,24 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const chance = new Chance();
 
+/**
+ * Build a log-query fixture command that cannot be a substring of another
+ * fixture command. chance.word() pairs like "gac"/"gactek" make
+ * `stdout.not.toContain(other)` fail when the shorter token appears inside
+ * the longer one in table output.
+ *
+ * Must stay ≤ 50 chars: log-format truncates COMMAND cells at MAX_COMMAND_LEN.
+ */
+function uniqueEchoCommand(label: string): string {
+    const command = `echo ${label}_${chance.hash({ length: 8 })}`;
+    if (command.length > 50) {
+        throw new Error(
+            `uniqueEchoCommand label too long (${command.length}): ${label}`,
+        );
+    }
+    return command;
+}
+
 const testDir = dirname(fileURLToPath(import.meta.url));
 const SHIM_SRC = resolve(testDir, "../../src/index.ts");
 const TSX_BIN = resolve(testDir, "../../../../node_modules/.bin/tsx");
@@ -103,7 +121,7 @@ function makeScriptEndEvent(overrides: Partial<Record<string, unknown>> = {}) {
         session_id: chance.guid(),
         event: "script_end",
         script: "test",
-        command: `echo ${chance.word()}`,
+        command: uniqueEchoCommand("default"),
         package: chance.word(),
         package_version: "1.0.0",
         actor: "human",
@@ -148,8 +166,8 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             const oldSessionId = chance.guid();
             const recentSessionId = chance.guid();
 
-            const oldCommand = `echo ${chance.word()}`;
-            const recentCommand = `echo ${chance.word()}`;
+            const oldCommand = uniqueEchoCommand("old-session");
+            const recentCommand = uniqueEchoCommand("recent-session");
 
             const oldEvent = makeScriptEndEvent({
                 session_id: oldSessionId,
@@ -189,8 +207,8 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             const targetActor = "claude-code";
             const otherActor = "human";
 
-            const targetCommand = `echo ${chance.word()}`;
-            const otherCommand = `echo ${chance.word()}`;
+            const targetCommand = uniqueEchoCommand("target-actor");
+            const otherCommand = uniqueEchoCommand("other-actor");
 
             const targetEvent = makeScriptEndEvent({
                 session_id: sessionId,
@@ -229,8 +247,8 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             const eventsDir = defaultEventsDir(tmpDir);
             const sessionId = chance.guid();
 
-            const failureCommand = `echo ${chance.word()}`;
-            const successCommand = `echo ${chance.word()}`;
+            const failureCommand = uniqueEchoCommand("failure");
+            const successCommand = uniqueEchoCommand("success");
 
             const failureEvent = makeScriptEndEvent({
                 session_id: sessionId,
@@ -266,8 +284,8 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             const targetScript = "test";
             const otherScript = "build";
 
-            const targetCommand = `echo ${chance.word()}`;
-            const otherCommand = `echo ${chance.word()}`;
+            const targetCommand = uniqueEchoCommand("target-script");
+            const otherCommand = uniqueEchoCommand("other-script");
 
             const targetEvent = makeScriptEndEvent({
                 session_id: sessionId,
@@ -306,8 +324,8 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             const eventsDir = defaultEventsDir(tmpDir);
             const sessionId = chance.guid();
 
-            const recentCommand = `echo ${chance.word()}`;
-            const oldCommand = `echo ${chance.word()}`;
+            const recentCommand = uniqueEchoCommand("recent-window");
+            const oldCommand = uniqueEchoCommand("old-window");
 
             const recentEvent = makeScriptEndEvent({
                 session_id: sessionId,
@@ -394,9 +412,9 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             const eventsDir = defaultEventsDir(tmpDir);
             const sessionId = chance.guid();
 
-            const matchCommand = `echo match-${chance.guid()}`;
-            const wrongActorCommand = `echo wrong-actor-${chance.guid()}`;
-            const successCommand = `echo success-${chance.guid()}`;
+            const matchCommand = uniqueEchoCommand("match");
+            const wrongActorCommand = uniqueEchoCommand("wrong-actor");
+            const successCommand = uniqueEchoCommand("success-and");
 
             const matchingEvent = makeScriptEndEvent({
                 session_id: sessionId,
@@ -445,7 +463,7 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             // Arrange
             const customDir = join(tmpDir, "custom-logs");
             const sessionId = chance.guid();
-            const customCommand = `echo ${chance.word()}`;
+            const customCommand = uniqueEchoCommand("custom-dir");
 
             const event = makeScriptEndEvent({
                 session_id: sessionId,
@@ -520,7 +538,7 @@ describe("Log query integration", { timeout: 30_000 }, () => {
             // Arrange
             const eventsDir = defaultEventsDir(tmpDir);
             const sessionId = chance.guid();
-            const validCommand = `echo ${chance.word()}`;
+            const validCommand = uniqueEchoCommand("valid-jsonl");
 
             // Build the poisoned JSON string directly (JS object literal syntax
             // treats "__proto__" as a prototype setter, not an own-property, so

--- a/packages/cli/api/copilot-with-fastify/.devcontainer/devcontainer.json
+++ b/packages/cli/api/copilot-with-fastify/.devcontainer/devcontainer.json
@@ -80,12 +80,12 @@
                     "context7": {
                         "type": "stdio",
                         "command": "npx",
-                        "args": ["@upstash/context7-mcp"]
+                        "args": ["@upstash/context7-mcp@4.0.0"]
                     },
                     "sequential-thinking": {
                         "command": "npx",
                         "args": [
-                            "@modelcontextprotocol/server-sequential-thinking"
+                            "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
                         ]
                     }
                 }

--- a/packages/cli/api/copilot-with-fastify/.vscode/mcp.json
+++ b/packages/cli/api/copilot-with-fastify/.vscode/mcp.json
@@ -3,12 +3,14 @@
         "context7": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@upstash/context7-mcp"]
+            "args": ["@upstash/context7-mcp@4.0.0"]
         },
         "sequential-thinking": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@modelcontextprotocol/server-sequential-thinking"]
+            "args": [
+                "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
+            ]
         },
         "lousy-agents": {
             "type": "stdio",

--- a/packages/cli/api/copilot-with-fastify/biome.template.json
+++ b/packages/cli/api/copilot-with-fastify/biome.template.json
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/cli/api/copilot-with-fastify/package-lock.json
+++ b/packages/cli/api/copilot-with-fastify/package-lock.json
@@ -17,12 +17,11 @@
                 "zod": "4.4.3"
             },
             "devDependencies": {
-                "@biomejs/biome": "2.5.3",
+                "@biomejs/biome": "2.5.7",
                 "@lousy-agents/mcp": "5.20.0",
                 "@modelcontextprotocol/server-sequential-thinking": "2026.7.4",
                 "@testcontainers/postgresql": "12.1.0",
                 "@types/node": "24.13.3",
-                "@upstash/context7-mcp": "4.0.0",
                 "chance": "1.1.13",
                 "testcontainers": "12.1.0",
                 "tsx": "4.23.11",
@@ -38,9 +37,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-            "integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.7.tgz",
+            "integrity": "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -54,20 +53,20 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.5.3",
-                "@biomejs/cli-darwin-x64": "2.5.3",
-                "@biomejs/cli-linux-arm64": "2.5.3",
-                "@biomejs/cli-linux-arm64-musl": "2.5.3",
-                "@biomejs/cli-linux-x64": "2.5.3",
-                "@biomejs/cli-linux-x64-musl": "2.5.3",
-                "@biomejs/cli-win32-arm64": "2.5.3",
-                "@biomejs/cli-win32-x64": "2.5.3"
+                "@biomejs/cli-darwin-arm64": "2.5.7",
+                "@biomejs/cli-darwin-x64": "2.5.7",
+                "@biomejs/cli-linux-arm64": "2.5.7",
+                "@biomejs/cli-linux-arm64-musl": "2.5.7",
+                "@biomejs/cli-linux-x64": "2.5.7",
+                "@biomejs/cli-linux-x64-musl": "2.5.7",
+                "@biomejs/cli-win32-arm64": "2.5.7",
+                "@biomejs/cli-win32-x64": "2.5.7"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-            "integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.7.tgz",
+            "integrity": "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==",
             "cpu": [
                 "arm64"
             ],
@@ -82,9 +81,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-            "integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.7.tgz",
+            "integrity": "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==",
             "cpu": [
                 "x64"
             ],
@@ -99,9 +98,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-            "integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.7.tgz",
+            "integrity": "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==",
             "cpu": [
                 "arm64"
             ],
@@ -119,9 +118,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-            "integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.7.tgz",
+            "integrity": "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==",
             "cpu": [
                 "arm64"
             ],
@@ -139,9 +138,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-            "integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.7.tgz",
+            "integrity": "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==",
             "cpu": [
                 "x64"
             ],
@@ -159,9 +158,9 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-            "integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.7.tgz",
+            "integrity": "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==",
             "cpu": [
                 "x64"
             ],
@@ -179,9 +178,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-            "integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.7.tgz",
+            "integrity": "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==",
             "cpu": [
                 "arm64"
             ],
@@ -196,9 +195,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-            "integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.7.tgz",
+            "integrity": "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==",
             "cpu": [
                 "x64"
             ],
@@ -979,54 +978,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@modelcontextprotocol/core": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
-            "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "zod": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/@modelcontextprotocol/node": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
-            "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@hono/node-server": "^1.19.9"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "peerDependencies": {
-                "@modelcontextprotocol/server": "^2.0.0",
-                "hono": "^4.11.4"
-            },
-            "peerDependenciesMeta": {
-                "hono": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@modelcontextprotocol/node/node_modules/@hono/node-server": {
-            "version": "1.19.17",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-            "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.14.1"
-            },
-            "peerDependencies": {
-                "hono": "^4"
-            }
-        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -1066,20 +1017,6 @@
                 "zod": {
                     "optional": false
                 }
-            }
-        },
-        "node_modules/@modelcontextprotocol/server": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
-            "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@modelcontextprotocol/core": "2.0.0",
-                "zod": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=20"
             }
         },
         "node_modules/@modelcontextprotocol/server-sequential-thinking": {
@@ -1519,17 +1456,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@types/body-parser": {
-            "version": "1.19.6",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1539,16 +1465,6 @@
             "dependencies": {
                 "@types/deep-eql": "*",
                 "assertion-error": "^2.0.1"
-            }
-        },
-        "node_modules/@types/connect": {
-            "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/deep-eql": {
@@ -1588,38 +1504,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/express": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
-            "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^5.0.0",
-                "@types/serve-static": "^2"
-            }
-        },
-        "node_modules/@types/express-serve-static-core": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
-            "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "node_modules/@types/http-errors": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/node": {
             "version": "24.13.3",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -1628,41 +1512,6 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.18.0"
-            }
-        },
-        "node_modules/@types/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/range-parser": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/send": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
-            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/serve-static": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
-            "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-errors": "*",
-                "@types/node": "*"
             }
         },
         "node_modules/@types/ssh2": {
@@ -2040,29 +1889,6 @@
             ],
             "engines": {
                 "node": ">=16.20.0"
-            }
-        },
-        "node_modules/@upstash/context7-mcp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@upstash/context7-mcp/-/context7-mcp-4.0.0.tgz",
-            "integrity": "sha512-7TlB85xbKbSHzI4G//3Qm+g8ryW11WZLd7PAOFdH5IxzAv1Yk+lcSBgDM4lDoYHXltzSwK7iUciiFNbFj7493Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@modelcontextprotocol/node": "2.0.0",
-                "@modelcontextprotocol/server": "2.0.0",
-                "@types/express": "^5.0.4",
-                "commander": "^13.1.0",
-                "express": "^5.1.0",
-                "jose": "^6.2.3",
-                "undici": "^7.0.0",
-                "zod": "^4.4.3"
-            },
-            "bin": {
-                "context7-mcp": "dist/index.js"
-            },
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/@vitest/expect": {
@@ -2856,16 +2682,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/commander": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/compress-commons": {
             "version": "6.0.2",
@@ -3867,9 +3683,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.32",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-            "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+            "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4603,9 +4419,9 @@
             "optional": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -5979,16 +5795,6 @@
                 "@typescript/typescript-sunos-x64": "7.0.2",
                 "@typescript/typescript-win32-arm64": "7.0.2",
                 "@typescript/typescript-win32-x64": "7.0.2"
-            }
-        },
-        "node_modules/undici": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {

--- a/packages/cli/api/copilot-with-fastify/package.json
+++ b/packages/cli/api/copilot-with-fastify/package.json
@@ -28,12 +28,11 @@
         "zod": "4.4.3"
     },
     "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.7",
         "@lousy-agents/mcp": "5.20.0",
         "@modelcontextprotocol/server-sequential-thinking": "2026.7.4",
         "@testcontainers/postgresql": "12.1.0",
         "@types/node": "24.13.3",
-        "@upstash/context7-mcp": "4.0.0",
         "chance": "1.1.13",
         "testcontainers": "12.1.0",
         "tsx": "4.23.11",

--- a/packages/cli/cli/copilot-with-citty/.devcontainer/devcontainer.json
+++ b/packages/cli/cli/copilot-with-citty/.devcontainer/devcontainer.json
@@ -68,12 +68,12 @@
                     "context7": {
                         "type": "stdio",
                         "command": "npx",
-                        "args": ["@upstash/context7-mcp"]
+                        "args": ["@upstash/context7-mcp@4.0.0"]
                     },
                     "sequential-thinking": {
                         "command": "npx",
                         "args": [
-                            "@modelcontextprotocol/server-sequential-thinking"
+                            "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
                         ]
                     }
                 }

--- a/packages/cli/cli/copilot-with-citty/.vscode/mcp.json
+++ b/packages/cli/cli/copilot-with-citty/.vscode/mcp.json
@@ -3,12 +3,14 @@
         "context7": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@upstash/context7-mcp"]
+            "args": ["@upstash/context7-mcp@4.0.0"]
         },
         "sequential-thinking": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@modelcontextprotocol/server-sequential-thinking"]
+            "args": [
+                "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
+            ]
         },
         "lousy-agents": {
             "type": "stdio",

--- a/packages/cli/cli/copilot-with-citty/biome.template.json
+++ b/packages/cli/cli/copilot-with-citty/biome.template.json
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/cli/cli/copilot-with-citty/package.json
+++ b/packages/cli/cli/copilot-with-citty/package.json
@@ -19,11 +19,10 @@
         "zod": "4.4.3"
     },
     "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.7",
         "@lousy-agents/mcp": "5.20.0",
         "@modelcontextprotocol/server-sequential-thinking": "2026.7.4",
         "@types/node": "24.13.3",
-        "@upstash/context7-mcp": "4.0.0",
         "chance": "1.1.13",
         "tsx": "4.23.11",
         "typescript": "7.0.2",

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -647,129 +647,137 @@ describe("Init command", () => {
             ["webapp", "package.json"],
             ["api", "package.json"],
             ["cli", "package.json"],
-        ])("should create expected scaffolding for %s project type", async (projectType: string, expectedFile: string) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(
-                projectType as SupportedProjectType,
-                projectName,
-            );
+        ])(
+            "should create expected scaffolding for %s project type",
+            async (projectType: string, expectedFile: string) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(
+                    projectType as SupportedProjectType,
+                    projectName,
+                );
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            const fullPath = join(testDir, expectedFile);
-            await expect(access(fullPath)).resolves.toBeUndefined();
-        });
+                // Assert
+                const fullPath = join(testDir, expectedFile);
+                await expect(access(fullPath)).resolves.toBeUndefined();
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create Vitest configuration files when %s project type is selected", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const vitestConfigFile = join(testDir, "vitest.config.ts");
-            const vitestSetupFile = join(testDir, "vitest.setup.ts");
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create Vitest configuration files when %s project type is selected",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const vitestConfigFile = join(testDir, "vitest.config.ts");
+                const vitestSetupFile = join(testDir, "vitest.setup.ts");
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(vitestConfigFile)).resolves.toBeUndefined();
-            await expect(access(vitestSetupFile)).resolves.toBeUndefined();
-        });
+                // Assert
+                await expect(access(vitestConfigFile)).resolves.toBeUndefined();
+                await expect(access(vitestSetupFile)).resolves.toBeUndefined();
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .github/workflows/copilot-setup-steps.yml for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const copilotSetupFile = join(
-                testDir,
-                ".github",
-                "workflows",
-                "copilot-setup-steps.yml",
-            );
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .github/workflows/copilot-setup-steps.yml for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const copilotSetupFile = join(
+                    testDir,
+                    ".github",
+                    "workflows",
+                    "copilot-setup-steps.yml",
+                );
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(copilotSetupFile)).resolves.toBeUndefined();
-            const content = await readFile(copilotSetupFile, "utf-8");
-            expect(content).toContain("name: Copilot Setup Steps");
-            expect(content).toContain("Checkout code");
+                // Assert
+                await expect(access(copilotSetupFile)).resolves.toBeUndefined();
+                const content = await readFile(copilotSetupFile, "utf-8");
+                expect(content).toContain("name: Copilot Setup Steps");
+                expect(content).toContain("Checkout code");
 
-            // Parse YAML and verify workflow structure
-            const workflow = parseYaml(content);
-            expect(workflow).toBeDefined();
-            expect(workflow).not.toBeNull();
-            expect(typeof workflow).toBe("object");
-            expect(workflow).toHaveProperty("jobs.copilot-setup-steps");
+                // Parse YAML and verify workflow structure
+                const workflow = parseYaml(content);
+                expect(workflow).toBeDefined();
+                expect(workflow).not.toBeNull();
+                expect(typeof workflow).toBe("object");
+                expect(workflow).toHaveProperty("jobs.copilot-setup-steps");
 
-            // Verify least-privilege permissions
-            const workflowObj = workflow as Record<string, unknown>;
-            expect(typeof workflowObj.jobs).toBe("object");
-            expect(workflowObj.jobs).not.toBeNull();
-            const jobs = workflowObj.jobs as Record<string, unknown>;
-            expect(typeof jobs["copilot-setup-steps"]).toBe("object");
-            expect(jobs["copilot-setup-steps"]).not.toBeNull();
-            const job = jobs["copilot-setup-steps"] as Record<string, unknown>;
-            expect(job.permissions).toEqual({
-                contents: "read",
-            });
+                // Verify least-privilege permissions
+                const workflowObj = workflow as Record<string, unknown>;
+                expect(typeof workflowObj.jobs).toBe("object");
+                expect(workflowObj.jobs).not.toBeNull();
+                const jobs = workflowObj.jobs as Record<string, unknown>;
+                expect(typeof jobs["copilot-setup-steps"]).toBe("object");
+                expect(jobs["copilot-setup-steps"]).not.toBeNull();
+                const job = jobs["copilot-setup-steps"] as Record<
+                    string,
+                    unknown
+                >;
+                expect(job.permissions).toEqual({
+                    contents: "read",
+                });
 
-            // Verify steps include checkout and node setup
-            expect(Array.isArray(job.steps)).toBe(true);
-            const steps = job.steps as Array<Record<string, unknown>>;
-            expect(steps.length).toBeGreaterThanOrEqual(2);
+                // Verify steps include checkout and node setup
+                expect(Array.isArray(job.steps)).toBe(true);
+                const steps = job.steps as Array<Record<string, unknown>>;
+                expect(steps.length).toBeGreaterThanOrEqual(2);
 
-            // Verify checkout action is SHA-pinned
-            const checkoutStep = steps.find((s) => s.name === "Checkout code");
-            expect(checkoutStep).toBeDefined();
-            expect(checkoutStep?.uses).toMatch(
-                /^actions\/checkout@[0-9a-f]{40}$/,
-            );
+                // Verify checkout action is SHA-pinned
+                const checkoutStep = steps.find(
+                    (s) => s.name === "Checkout code",
+                );
+                expect(checkoutStep).toBeDefined();
+                expect(checkoutStep?.uses).toMatch(
+                    /^actions\/checkout@[0-9a-f]{40}$/,
+                );
 
-            // Verify Node.js setup is included and SHA-pinned
-            const nodeSetupStep = steps.find((s) => s.name === "Setup node");
-            expect(nodeSetupStep).toBeDefined();
-            expect(nodeSetupStep?.uses).toMatch(
-                /^actions\/setup-node@[0-9a-f]{40}$/,
-            );
-            expect(nodeSetupStep?.with).toHaveProperty(
-                "node-version-file",
-                ".nvmrc",
-            );
+                // Verify Node.js setup is included and SHA-pinned
+                const nodeSetupStep = steps.find(
+                    (s) => s.name === "Setup node",
+                );
+                expect(nodeSetupStep).toBeDefined();
+                expect(nodeSetupStep?.uses).toMatch(
+                    /^actions\/setup-node@[0-9a-f]{40}$/,
+                );
+                expect(nodeSetupStep?.with).toHaveProperty(
+                    "node-version-file",
+                    ".nvmrc",
+                );
 
-            // Verify a Node.js install step is present
-            const installStep = steps.find(
-                (s) => s.name === "Install Node.js dependencies",
-            );
-            expect(installStep).toBeDefined();
-            expect(typeof installStep?.run).toBe("string");
-        });
+                // Verify a Node.js install step is present
+                const installStep = steps.find(
+                    (s) => s.name === "Install Node.js dependencies",
+                );
+                expect(installStep).toBeDefined();
+                expect(typeof installStep?.run).toBe("string");
+            },
+        );
 
         it("should preserve existing copilot-setup-steps.yml workflow file", async () => {
             // Arrange
@@ -813,224 +821,271 @@ jobs:
             expect(actualContent).not.toContain("Copilot Setup Steps");
         });
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .github/instructions directory with instruction files for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const instructionsDir = join(testDir, ".github", "instructions");
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .github/instructions directory with instruction files for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const instructionsDir = join(
+                    testDir,
+                    ".github",
+                    "instructions",
+                );
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(instructionsDir)).resolves.toBeUndefined();
-            await expect(
-                access(join(instructionsDir, "test.instructions.md")),
-            ).resolves.toBeUndefined();
-            await expect(
-                access(join(instructionsDir, "spec.instructions.md")),
-            ).resolves.toBeUndefined();
-            await expect(
-                access(join(instructionsDir, "pipeline.instructions.md")),
-            ).resolves.toBeUndefined();
-            await expect(
-                access(
-                    join(
-                        instructionsDir,
-                        "software-architecture.instructions.md",
+                // Assert
+                await expect(access(instructionsDir)).resolves.toBeUndefined();
+                await expect(
+                    access(join(instructionsDir, "test.instructions.md")),
+                ).resolves.toBeUndefined();
+                await expect(
+                    access(join(instructionsDir, "spec.instructions.md")),
+                ).resolves.toBeUndefined();
+                await expect(
+                    access(join(instructionsDir, "pipeline.instructions.md")),
+                ).resolves.toBeUndefined();
+                await expect(
+                    access(
+                        join(
+                            instructionsDir,
+                            "software-architecture.instructions.md",
+                        ),
                     ),
-                ),
-            ).resolves.toBeUndefined();
-        });
+                ).resolves.toBeUndefined();
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .github/ISSUE_TEMPLATE/feature-to-spec.yml for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const featureToSpecFile = join(
-                testDir,
-                ".github",
-                "ISSUE_TEMPLATE",
-                "feature-to-spec.yml",
-            );
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .github/ISSUE_TEMPLATE/feature-to-spec.yml for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const featureToSpecFile = join(
+                    testDir,
+                    ".github",
+                    "ISSUE_TEMPLATE",
+                    "feature-to-spec.yml",
+                );
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(featureToSpecFile)).resolves.toBeUndefined();
-            const content = await readFile(featureToSpecFile, "utf-8");
-            expect(content).toContain("Copilot Feature To Spec");
-            expect(content).toContain("copilot-ready");
-        });
+                // Assert
+                await expect(
+                    access(featureToSpecFile),
+                ).resolves.toBeUndefined();
+                const content = await readFile(featureToSpecFile, "utf-8");
+                expect(content).toContain("Copilot Feature To Spec");
+                expect(content).toContain("copilot-ready");
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .github/workflows/assign-copilot.yml for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const assignCopilotFile = join(
-                testDir,
-                ".github",
-                "workflows",
-                "assign-copilot.yml",
-            );
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .github/workflows/assign-copilot.yml for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const assignCopilotFile = join(
+                    testDir,
+                    ".github",
+                    "workflows",
+                    "assign-copilot.yml",
+                );
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(assignCopilotFile)).resolves.toBeUndefined();
-            const content = await readFile(assignCopilotFile, "utf-8");
-            expect(content).toContain("Auto-Assign Copilot");
-            expect(content).toContain("@copilot");
-        });
+                // Assert
+                await expect(
+                    access(assignCopilotFile),
+                ).resolves.toBeUndefined();
+                const content = await readFile(assignCopilotFile, "utf-8");
+                expect(content).toContain("Auto-Assign Copilot");
+                expect(content).toContain("@copilot");
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .github/specs/README.md for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const specsReadmeFile = join(
-                testDir,
-                ".github",
-                "specs",
-                "README.md",
-            );
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .github/specs/README.md for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const specsReadmeFile = join(
+                    testDir,
+                    ".github",
+                    "specs",
+                    "README.md",
+                );
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(specsReadmeFile)).resolves.toBeUndefined();
-            const content = await readFile(specsReadmeFile, "utf-8");
-            expect(content).toContain("Specifications Directory");
-            expect(content).toContain("EARS");
-        });
+                // Assert
+                await expect(access(specsReadmeFile)).resolves.toBeUndefined();
+                const content = await readFile(specsReadmeFile, "utf-8");
+                expect(content).toContain("Specifications Directory");
+                expect(content).toContain("EARS");
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .gitignore for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const gitignoreFile = join(testDir, ".gitignore");
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .gitignore for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const gitignoreFile = join(testDir, ".gitignore");
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(gitignoreFile)).resolves.toBeUndefined();
-            const content = await readFile(gitignoreFile, "utf-8");
-            expect(content).toContain("node_modules/");
-            if (projectType === "webapp") {
-                expect(content).toContain(".next/");
-            } else {
-                expect(content).not.toContain(".next/");
-            }
-        });
+                // Assert
+                await expect(access(gitignoreFile)).resolves.toBeUndefined();
+                const content = await readFile(gitignoreFile, "utf-8");
+                expect(content).toContain("node_modules/");
+                if (projectType === "webapp") {
+                    expect(content).toContain(".next/");
+                } else {
+                    expect(content).not.toContain(".next/");
+                }
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .vscode/mcp.json with correct MCP server args for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const mcpJsonFile = join(testDir, ".vscode", "mcp.json");
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .vscode/mcp.json with correct MCP server args for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const mcpJsonFile = join(testDir, ".vscode", "mcp.json");
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            await expect(access(mcpJsonFile)).resolves.toBeUndefined();
-            const content = await readFile(mcpJsonFile, "utf-8");
-            const parsed = JSON.parse(content) as {
-                servers: {
-                    "lousy-agents": { args: string[] };
+                // Assert
+                await expect(access(mcpJsonFile)).resolves.toBeUndefined();
+                const content = await readFile(mcpJsonFile, "utf-8");
+                const parsed = JSON.parse(content) as {
+                    servers: {
+                        context7: { args: string[] };
+                        "sequential-thinking": { args: string[] };
+                        "lousy-agents": { args: string[] };
+                    };
                 };
-            };
-            expect(parsed.servers["lousy-agents"].args).toEqual([
-                "-p",
-                "@lousy-agents/mcp",
-                "lousy-agents-mcp",
-            ]);
-        });
+                expect(parsed.servers.context7.args).toEqual([
+                    "@upstash/context7-mcp@4.0.0",
+                ]);
+                expect(parsed.servers["sequential-thinking"].args).toEqual([
+                    "@modelcontextprotocol/server-sequential-thinking@2026.7.4",
+                ]);
+                expect(parsed.servers["lousy-agents"].args).toEqual([
+                    "-p",
+                    "@lousy-agents/mcp",
+                    "lousy-agents-mcp",
+                ]);
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should create .github/workflows/ci.yml with lint, test, and build jobs for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const ciYmlFile = join(testDir, ".github", "workflows", "ci.yml");
+                const packageJsonFile = join(testDir, "package.json");
+                const packageJson = await readFile(packageJsonFile, "utf-8");
+                expect(packageJson).not.toContain("@upstash/context7-mcp");
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                const devcontainerFile = join(
+                    testDir,
+                    ".devcontainer",
+                    "devcontainer.json",
+                );
+                const devcontainerContent = await readFile(
+                    devcontainerFile,
+                    "utf-8",
+                );
+                const devcontainer = JSON.parse(devcontainerContent);
+                expect(devcontainer).toMatchObject({
+                    customizations: {
+                        vscode: {
+                            mcp: {
+                                servers: {
+                                    context7: {
+                                        args: ["@upstash/context7-mcp@4.0.0"],
+                                    },
+                                    "sequential-thinking": {
+                                        args: [
+                                            "@modelcontextprotocol/server-sequential-thinking@2026.7.4",
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            },
+        );
 
-            // Assert
-            await expect(access(ciYmlFile)).resolves.toBeUndefined();
-            const content = await readFile(ciYmlFile, "utf-8");
-            expect(content).toContain("name: CI");
-            expect(content).toContain("jobs:");
-            expect(content).toContain("lint:");
-            expect(content).toContain("build:");
-            expect(content).toMatch(/needs:\s*\[lint/);
-        });
+        it.each(["webapp", "api", "cli"] as const)(
+            "should create .github/workflows/ci.yml with lint, test, and build jobs for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const ciYmlFile = join(
+                    testDir,
+                    ".github",
+                    "workflows",
+                    "ci.yml",
+                );
+
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
+
+                // Assert
+                await expect(access(ciYmlFile)).resolves.toBeUndefined();
+                const content = await readFile(ciYmlFile, "utf-8");
+                expect(content).toContain("name: CI");
+                expect(content).toContain("jobs:");
+                expect(content).toContain("lint:");
+                expect(content).toContain("build:");
+                expect(content).toMatch(/needs:\s*\[lint/);
+            },
+        );
     });
 
     describe("when preserving existing files across project types", () => {
@@ -1045,118 +1100,121 @@ jobs:
             await teardownTestDir(testDir);
         });
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should preserve existing feature-to-spec.yml file for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const issueTemplateDir = join(testDir, ".github", "ISSUE_TEMPLATE");
-            const featureToSpecFile = join(
-                issueTemplateDir,
-                "feature-to-spec.yml",
-            );
-            const existingContent = `---\nname: Custom Template\n`;
-            await mkdir(issueTemplateDir, { recursive: true });
-            await writeFile(featureToSpecFile, existingContent);
+        it.each(["webapp", "api", "cli"] as const)(
+            "should preserve existing feature-to-spec.yml file for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const issueTemplateDir = join(
+                    testDir,
+                    ".github",
+                    "ISSUE_TEMPLATE",
+                );
+                const featureToSpecFile = join(
+                    issueTemplateDir,
+                    "feature-to-spec.yml",
+                );
+                const existingContent = `---\nname: Custom Template\n`;
+                await mkdir(issueTemplateDir, { recursive: true });
+                await writeFile(featureToSpecFile, existingContent);
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            const content = await readFile(featureToSpecFile, "utf-8");
-            expect(content).toBe(existingContent);
-        });
+                // Assert
+                const content = await readFile(featureToSpecFile, "utf-8");
+                expect(content).toBe(existingContent);
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should preserve existing assign-copilot.yml file for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const workflowsDir = join(testDir, ".github", "workflows");
-            const assignCopilotFile = join(workflowsDir, "assign-copilot.yml");
-            const existingContent = `---\nname: Custom Workflow\n`;
-            await mkdir(workflowsDir, { recursive: true });
-            await writeFile(assignCopilotFile, existingContent);
+        it.each(["webapp", "api", "cli"] as const)(
+            "should preserve existing assign-copilot.yml file for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const workflowsDir = join(testDir, ".github", "workflows");
+                const assignCopilotFile = join(
+                    workflowsDir,
+                    "assign-copilot.yml",
+                );
+                const existingContent = `---\nname: Custom Workflow\n`;
+                await mkdir(workflowsDir, { recursive: true });
+                await writeFile(assignCopilotFile, existingContent);
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            const content = await readFile(assignCopilotFile, "utf-8");
-            expect(content).toBe(existingContent);
-        });
+                // Assert
+                const content = await readFile(assignCopilotFile, "utf-8");
+                expect(content).toBe(existingContent);
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should preserve existing specs directory content for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const specsDir = join(testDir, ".github", "specs");
-            const existingSpecFile = join(specsDir, "existing-spec.md");
-            const existingContent = `# Existing Spec\n\nSome content`;
-            await mkdir(specsDir, { recursive: true });
-            await writeFile(existingSpecFile, existingContent);
+        it.each(["webapp", "api", "cli"] as const)(
+            "should preserve existing specs directory content for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const specsDir = join(testDir, ".github", "specs");
+                const existingSpecFile = join(specsDir, "existing-spec.md");
+                const existingContent = `# Existing Spec\n\nSome content`;
+                await mkdir(specsDir, { recursive: true });
+                await writeFile(existingSpecFile, existingContent);
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            const content = await readFile(existingSpecFile, "utf-8");
-            expect(content).toBe(existingContent);
-        });
+                // Assert
+                const content = await readFile(existingSpecFile, "utf-8");
+                expect(content).toBe(existingContent);
+            },
+        );
 
-        it.each([
-            "webapp",
-            "api",
-            "cli",
-        ] as const)("should preserve existing package.json file for %s project type", async (projectType) => {
-            // Arrange
-            const projectName = chance.word().toLowerCase();
-            mockPrompt = createMockPrompt(projectType, projectName);
-            const packageJsonFile = join(testDir, "package.json");
-            const existingContent = JSON.stringify(
-                { name: chance.word(), version: "1.0.0" },
-                null,
-                2,
-            );
-            await writeFile(packageJsonFile, existingContent);
+        it.each(["webapp", "api", "cli"] as const)(
+            "should preserve existing package.json file for %s project type",
+            async (projectType) => {
+                // Arrange
+                const projectName = chance.word().toLowerCase();
+                mockPrompt = createMockPrompt(projectType, projectName);
+                const packageJsonFile = join(testDir, "package.json");
+                const existingContent = JSON.stringify(
+                    { name: chance.word(), version: "1.0.0" },
+                    null,
+                    2,
+                );
+                await writeFile(packageJsonFile, existingContent);
 
-            // Act
-            await initCommand.run({
-                rawArgs: [],
-                args: { _: [] },
-                cmd: initCommand,
-                data: { prompt: mockPrompt, targetDir: testDir },
-            });
+                // Act
+                await initCommand.run({
+                    rawArgs: [],
+                    args: { _: [] },
+                    cmd: initCommand,
+                    data: { prompt: mockPrompt, targetDir: testDir },
+                });
 
-            // Assert
-            const content = await readFile(packageJsonFile, "utf-8");
-            expect(content).toBe(existingContent);
-        });
+                // Assert
+                const content = await readFile(packageJsonFile, "utf-8");
+                expect(content).toBe(existingContent);
+            },
+        );
     });
 
     describe("when using CLI arguments", () => {
@@ -1273,50 +1331,53 @@ jobs:
             ["webapp", "package.json"],
             ["api", "package.json"],
             ["cli", "package.json"],
-        ])("should create identical project structure for %s type regardless of input method", async (projectType: string, verifyPath: string) => {
-            // Arrange
-            const cliTestDir = join(tmpdir(), `test-cli-${chance.guid()}`);
-            const promptTestDir = join(
-                tmpdir(),
-                `test-prompt-${chance.guid()}`,
-            );
-            await mkdir(cliTestDir, { recursive: true });
-            await mkdir(promptTestDir, { recursive: true });
-            const projectName = chance.word().toLowerCase();
-            const mockPrompt = vi
-                .fn()
-                .mockResolvedValueOnce(projectType)
-                .mockResolvedValueOnce(projectName);
+        ])(
+            "should create identical project structure for %s type regardless of input method",
+            async (projectType: string, verifyPath: string) => {
+                // Arrange
+                const cliTestDir = join(tmpdir(), `test-cli-${chance.guid()}`);
+                const promptTestDir = join(
+                    tmpdir(),
+                    `test-prompt-${chance.guid()}`,
+                );
+                await mkdir(cliTestDir, { recursive: true });
+                await mkdir(promptTestDir, { recursive: true });
+                const projectName = chance.word().toLowerCase();
+                const mockPrompt = vi
+                    .fn()
+                    .mockResolvedValueOnce(projectType)
+                    .mockResolvedValueOnce(projectName);
 
-            try {
-                // Act
-                await initCommand.run({
-                    rawArgs: ["--kind", projectType, "--name", projectName],
-                    args: { _: [], kind: projectType, name: projectName },
-                    cmd: initCommand,
-                    data: { prompt: vi.fn(), targetDir: cliTestDir },
-                });
+                try {
+                    // Act
+                    await initCommand.run({
+                        rawArgs: ["--kind", projectType, "--name", projectName],
+                        args: { _: [], kind: projectType, name: projectName },
+                        cmd: initCommand,
+                        data: { prompt: vi.fn(), targetDir: cliTestDir },
+                    });
 
-                await initCommand.run({
-                    rawArgs: [],
-                    args: { _: [] },
-                    cmd: initCommand,
-                    data: {
-                        prompt: mockPrompt,
-                        targetDir: promptTestDir,
-                    },
-                });
+                    await initCommand.run({
+                        rawArgs: [],
+                        args: { _: [] },
+                        cmd: initCommand,
+                        data: {
+                            prompt: mockPrompt,
+                            targetDir: promptTestDir,
+                        },
+                    });
 
-                // Assert
-                const cliPath = join(cliTestDir, verifyPath);
-                const promptPath = join(promptTestDir, verifyPath);
-                await expect(access(cliPath)).resolves.toBeUndefined();
-                await expect(access(promptPath)).resolves.toBeUndefined();
-            } finally {
-                await rm(cliTestDir, { recursive: true, force: true });
-                await rm(promptTestDir, { recursive: true, force: true });
-            }
-        });
+                    // Assert
+                    const cliPath = join(cliTestDir, verifyPath);
+                    const promptPath = join(promptTestDir, verifyPath);
+                    await expect(access(cliPath)).resolves.toBeUndefined();
+                    await expect(access(promptPath)).resolves.toBeUndefined();
+                } finally {
+                    await rm(cliTestDir, { recursive: true, force: true });
+                    await rm(promptTestDir, { recursive: true, force: true });
+                }
+            },
+        );
     });
 
     describe("when project name is provided", () => {

--- a/packages/cli/src/lib/config.test.ts
+++ b/packages/cli/src/lib/config.test.ts
@@ -1,6 +1,28 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { consola } from "consola";
 import { describe, expect, it, vi } from "vitest";
 import { getProjectStructure, loadInitConfig } from "./config.js";
+
+const CLI_SRC_LIB_DIR = dirname(fileURLToPath(import.meta.url));
+const MONOREPO_ROOT = join(CLI_SRC_LIB_DIR, "../../../..");
+const API_TEMPLATE_DIR = join(
+    CLI_SRC_LIB_DIR,
+    "../../api/copilot-with-fastify",
+);
+
+function lockfileHasHonoNodeServer1x(lockfilePath: string): boolean {
+    const lockfile = JSON.parse(readFileSync(lockfilePath, "utf-8")) as {
+        packages?: Record<string, { version?: string }>;
+    };
+    return Object.entries(lockfile.packages ?? {}).some(
+        ([path, meta]) =>
+            path.endsWith("node_modules/@hono/node-server") &&
+            typeof meta.version === "string" &&
+            meta.version.startsWith("1."),
+    );
+}
 
 describe("Config", () => {
     describe("loadInitConfig", () => {
@@ -187,55 +209,55 @@ describe("Config", () => {
             );
         });
 
-        it.each([
-            "cli",
-            "webapp",
-            "api",
-        ] as const)("should include feature-to-plan skill files with content in %s structure", async (projectType) => {
-            // Act
-            const structure = await getProjectStructure(projectType);
+        it.each(["cli", "webapp", "api"] as const)(
+            "should include feature-to-plan skill files with content in %s structure",
+            async (projectType) => {
+                // Act
+                const structure = await getProjectStructure(projectType);
 
-            // Assert — verify file nodes exist and have non-empty, correct content
-            const skillFileExpectations: Array<[string, string, number]> = [
-                [
-                    ".agents/skills/feature-to-plan/SKILL.md",
-                    "Approval Gate",
-                    2000,
-                ],
-                [
-                    ".agents/skills/feature-to-plan/references/interactive-flow.md",
-                    "Phase 1",
-                    3000,
-                ],
-                [
-                    ".agents/skills/feature-to-plan/references/spec-format.md",
-                    "EARS",
-                    1000,
-                ],
-            ];
+                // Assert — verify file nodes exist and have non-empty, correct content
+                const skillFileExpectations: Array<[string, string, number]> = [
+                    [
+                        ".agents/skills/feature-to-plan/SKILL.md",
+                        "Approval Gate",
+                        2000,
+                    ],
+                    [
+                        ".agents/skills/feature-to-plan/references/interactive-flow.md",
+                        "Phase 1",
+                        3000,
+                    ],
+                    [
+                        ".agents/skills/feature-to-plan/references/spec-format.md",
+                        "EARS",
+                        1000,
+                    ],
+                ];
 
-            for (const [
-                filePath,
-                expectedContent,
-                minLength,
-            ] of skillFileExpectations) {
-                const fileNode = structure?.nodes.find(
-                    (node) => node.type === "file" && node.path === filePath,
-                );
-                expect(
-                    fileNode,
-                    `Expected file node for ${filePath} in ${projectType} structure`,
-                ).toBeDefined();
-                expect(
-                    fileNode?.content,
-                    `Expected ${filePath} to contain "${expectedContent}"`,
-                ).toContain(expectedContent);
-                expect(
-                    fileNode?.content.length,
-                    `Expected ${filePath} content length to be at least ${minLength}`,
-                ).toBeGreaterThanOrEqual(minLength);
-            }
-        });
+                for (const [
+                    filePath,
+                    expectedContent,
+                    minLength,
+                ] of skillFileExpectations) {
+                    const fileNode = structure?.nodes.find(
+                        (node) =>
+                            node.type === "file" && node.path === filePath,
+                    );
+                    expect(
+                        fileNode,
+                        `Expected file node for ${filePath} in ${projectType} structure`,
+                    ).toBeDefined();
+                    expect(
+                        fileNode?.content,
+                        `Expected ${filePath} to contain "${expectedContent}"`,
+                    ).toContain(expectedContent);
+                    expect(
+                        fileNode?.content.length,
+                        `Expected ${filePath} content length to be at least ${minLength}`,
+                    ).toBeGreaterThanOrEqual(minLength);
+                }
+            },
+        );
 
         it("should keep feature-to-plan skill file content identical across all project types", async () => {
             // Arrange
@@ -274,34 +296,155 @@ describe("Config", () => {
             }
         });
 
-        it.each([
-            "cli",
-            "webapp",
-            "api",
-        ] as const)("should include feature-to-plan skill directory nodes in %s structure", async (projectType) => {
-            // Act
-            const structure = await getProjectStructure(projectType);
-
-            // Assert — directory nodes must be present so the scaffold writer
-            // can create files under them without failing at runtime
-            const skillDirs = [
-                ".agents",
-                ".agents/skills",
-                ".agents/skills/feature-to-plan",
-                ".agents/skills/feature-to-plan/references",
-            ];
-
-            for (const dirPath of skillDirs) {
-                const dirNode = structure?.nodes.find(
-                    (node) =>
-                        node.type === "directory" && node.path === dirPath,
-                );
-                expect(
-                    dirNode,
-                    `Expected directory node for ${dirPath} in ${projectType} structure`,
-                ).toBeDefined();
-            }
+        it("should not resolve @hono/node-server 1.x in monorepo or api scaffold lockfiles", () => {
+            expect(
+                lockfileHasHonoNodeServer1x(
+                    join(MONOREPO_ROOT, "package-lock.json"),
+                ),
+            ).toBe(false);
+            expect(
+                lockfileHasHonoNodeServer1x(
+                    join(API_TEMPLATE_DIR, "package-lock.json"),
+                ),
+            ).toBe(false);
         });
+
+        it("should pin monorepo devcontainer MCP installs and omit context7 from root package.json", () => {
+            const rootPackageJson = readFileSync(
+                join(MONOREPO_ROOT, "package.json"),
+                "utf-8",
+            );
+            expect(rootPackageJson).not.toContain("@upstash/context7-mcp");
+
+            const setupSh = readFileSync(
+                join(MONOREPO_ROOT, ".devcontainer/setup.sh"),
+                "utf-8",
+            );
+            expect(setupSh).toContain("@upstash/context7-mcp@4.0.0");
+            expect(setupSh).toContain(
+                "@modelcontextprotocol/server-sequential-thinking@2026.7.4",
+            );
+            expect(setupSh).not.toMatch(/@upstash\/context7-mcp(?!@4\.0\.0)/);
+
+            const rootDevcontainer = JSON.parse(
+                readFileSync(
+                    join(MONOREPO_ROOT, ".devcontainer/devcontainer.json"),
+                    "utf-8",
+                ),
+            );
+            expect(rootDevcontainer).toMatchObject({
+                customizations: {
+                    vscode: {
+                        mcp: {
+                            servers: {
+                                context7: {
+                                    args: ["@upstash/context7-mcp@4.0.0"],
+                                },
+                                "sequential-thinking": {
+                                    args: [
+                                        "@modelcontextprotocol/server-sequential-thinking@2026.7.4",
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            });
+        });
+
+        it.each(["cli", "webapp", "api"] as const)(
+            "should not list @upstash/context7-mcp in %s package.json (lockfile hygiene)",
+            async (projectType) => {
+                const structure = await getProjectStructure(projectType);
+                const packageJson = structure?.nodes.find(
+                    (node) =>
+                        node.type === "file" && node.path === "package.json",
+                )?.content;
+                expect(packageJson).toBeDefined();
+                expect(packageJson).not.toContain("@upstash/context7-mcp");
+            },
+        );
+
+        it.each(["cli", "webapp", "api"] as const)(
+            "should pin MCP package versions in %s .vscode/mcp.json and devcontainer",
+            async (projectType) => {
+                const structure = await getProjectStructure(projectType);
+                const mcpJson = structure?.nodes.find(
+                    (node) =>
+                        node.type === "file" &&
+                        node.path === ".vscode/mcp.json",
+                )?.content;
+                expect(mcpJson).toBeDefined();
+                expect(mcpJson).toEqual(expect.any(String));
+                const parsed = JSON.parse(String(mcpJson));
+                expect(parsed).toMatchObject({
+                    servers: {
+                        context7: {
+                            args: ["@upstash/context7-mcp@4.0.0"],
+                        },
+                        "sequential-thinking": {
+                            args: [
+                                "@modelcontextprotocol/server-sequential-thinking@2026.7.4",
+                            ],
+                        },
+                    },
+                });
+
+                const devcontainerJson = structure?.nodes.find(
+                    (node) =>
+                        node.type === "file" &&
+                        node.path === ".devcontainer/devcontainer.json",
+                )?.content;
+                expect(devcontainerJson).toBeDefined();
+                const devcontainer = JSON.parse(String(devcontainerJson));
+                expect(devcontainer).toMatchObject({
+                    customizations: {
+                        vscode: {
+                            mcp: {
+                                servers: {
+                                    context7: {
+                                        args: ["@upstash/context7-mcp@4.0.0"],
+                                    },
+                                    "sequential-thinking": {
+                                        args: [
+                                            "@modelcontextprotocol/server-sequential-thinking@2026.7.4",
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            },
+        );
+
+        it.each(["cli", "webapp", "api"] as const)(
+            "should include feature-to-plan skill directory nodes in %s structure",
+            async (projectType) => {
+                // Act
+                const structure = await getProjectStructure(projectType);
+
+                // Assert — directory nodes must be present so the scaffold writer
+                // can create files under them without failing at runtime
+                const skillDirs = [
+                    ".agents",
+                    ".agents/skills",
+                    ".agents/skills/feature-to-plan",
+                    ".agents/skills/feature-to-plan/references",
+                ];
+
+                for (const dirPath of skillDirs) {
+                    const dirNode = structure?.nodes.find(
+                        (node) =>
+                            node.type === "directory" && node.path === dirPath,
+                    );
+                    expect(
+                        dirNode,
+                        `Expected directory node for ${dirPath} in ${projectType} structure`,
+                    ).toBeDefined();
+                }
+            },
+        );
 
         it("should throw a descriptive error when a feature-to-plan skill file is missing", async () => {
             const missingRelativePath =

--- a/packages/cli/ui/copilot-with-react/.devcontainer/devcontainer.json
+++ b/packages/cli/ui/copilot-with-react/.devcontainer/devcontainer.json
@@ -74,12 +74,12 @@
                     "context7": {
                         "type": "stdio",
                         "command": "npx",
-                        "args": ["@upstash/context7-mcp"]
+                        "args": ["@upstash/context7-mcp@4.0.0"]
                     },
                     "sequential-thinking": {
                         "command": "npx",
                         "args": [
-                            "@modelcontextprotocol/server-sequential-thinking"
+                            "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
                         ]
                     }
                 }

--- a/packages/cli/ui/copilot-with-react/.vscode/mcp.json
+++ b/packages/cli/ui/copilot-with-react/.vscode/mcp.json
@@ -3,12 +3,14 @@
         "context7": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@upstash/context7-mcp"]
+            "args": ["@upstash/context7-mcp@4.0.0"]
         },
         "sequential-thinking": {
             "type": "stdio",
             "command": "npx",
-            "args": ["@modelcontextprotocol/server-sequential-thinking"]
+            "args": [
+                "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
+            ]
         },
         "lousy-agents": {
             "type": "stdio",

--- a/packages/cli/ui/copilot-with-react/biome.template.json
+++ b/packages/cli/ui/copilot-with-react/biome.template.json
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/cli/ui/copilot-with-react/package.json
+++ b/packages/cli/ui/copilot-with-react/package.json
@@ -21,7 +21,7 @@
         "react-dom": "19.2.8"
     },
     "devDependencies": {
-        "@biomejs/biome": "2.5.3",
+        "@biomejs/biome": "2.5.7",
         "@eslint/eslintrc": "3.3.6",
         "@lousy-agents/mcp": "5.20.0",
         "@modelcontextprotocol/server-sequential-thinking": "2026.7.4",
@@ -30,7 +30,6 @@
         "@types/node": "24.13.3",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
-        "@upstash/context7-mcp": "4.0.0",
         "@vitejs/plugin-react": "6.0.5",
         "@vitest/ui": "4.1.10",
         "eslint": "10.8.1",


### PR DESCRIPTION
## Summary

- Clear open Dependabot alerts **#151, #152, #164–#166** without npm overrides by removing `@upstash/context7-mcp` from install graphs and refreshing nested scaffold lockfiles (`hono` ≥4.12.34, no `@hono/node-server@1.x`, patched `nanoid`).
- Upgrade `@biomejs/biome` to **2.5.7** and apply formatter output (supersedes Renovate **#959**, which failed format-check / was conflicted).
- Pin MCP `npx` package versions in scaffold + monorepo configs so registry floats cannot bypass lockfile hygiene.
- Document accepted residual runtime risk: pinned `npx @upstash/context7-mcp@4.0.0` still pulls hono node-server 1.x until upstream fixes.
- Regression tests for package.json / lockfile / MCP pin contracts.
- Fix flaky `agent-shell` log-query test: `chance.word()` pairs like `gac`/`gactek` made `not.toContain(other)` fail when one command is a substring of another in table output.

## Dependabot

| Alert | Package | Resolution |
|-------|---------|------------|
| #164–#166 | `hono` in nested scaffold lockfile | Refresh → 4.13.1 |
| #151–#152 | `@hono/node-server` 1.x via context7→mcp/node | Remove context7-mcp from package.json (no overrides) |

## PR #959

Supersedes https://github.com/zpratt/lousy-agents/pull/959 (Biome 2.5.7 format-check failure + merge conflicts).

## Test plan

- [x] `mise run ci`
- [x] `npm audit` clean on root + nested API lockfile
- [x] log-query integration test ×15 consecutive passes
- [ ] CI green on PR