### PR TITLE
feat(lint): ordered-splice multi-hop isolation black-box acceptance (#1105)

### DIFF
--- a/.github/workflows/close-issues-on-beta-merge.yml
+++ b/.github/workflows/close-issues-on-beta-merge.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close issues referenced by Closes/Fixes keywords
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const body = context.payload.pull_request.body || "";

--- a/.github/workflows/close-issues-on-beta-merge.yml
+++ b/.github/workflows/close-issues-on-beta-merge.yml
@@ -1,0 +1,63 @@
+# GitHub only auto-closes issues for merges into the default branch (main).
+# Epic slice work targets beta; this workflow honors Closes/Fixes keywords on beta merges.
+name: Close issues on beta merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [beta]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by Closes/Fixes keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const title = context.payload.pull_request.title || "";
+            const text = `${title}\n${body}`;
+            const re =
+              /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            const numbers = new Set();
+            for (const match of text.matchAll(re)) {
+              numbers.add(Number(match[1]));
+            }
+            if (numbers.size === 0) {
+              core.info("No Closes/Fixes issue references found");
+              return;
+            }
+            const prUrl = context.payload.pull_request.html_url;
+            const prNumber = context.payload.pull_request.number;
+            for (const issue_number of numbers) {
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+              });
+              if (issue.data.state === "closed") {
+                core.info(`#${issue_number} already closed`);
+                continue;
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: `Closed by #${prNumber} merged into \`beta\`.\n\n${prUrl}`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: "closed",
+                state_reason: "completed",
+              });
+              core.info(`Closed #${issue_number}`);
+            }

--- a/packages/cli/src/commands/lint-claude-import.integration.test.ts
+++ b/packages/cli/src/commands/lint-claude-import.integration.test.ts
@@ -1,0 +1,722 @@
+/**
+ * Black-box CLI acceptance locks for Claude `@` instruction import expansion
+ * (matrix cells A2–A6, A11–A13 + deterministic diagnostic ordering).
+ *
+ * Runs the real CLI entrypoint via tsx against tmpdir fixtures with real discovery
+ * (root CLAUDE.md + AGENTS.md only as entrypoints).
+ */
+
+import { execFile } from "node:child_process";
+import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import Chance from "chance";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const chance = new Chance();
+
+const cliPackageDir = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+);
+
+/** Mirrors DEFAULT_STRUCTURAL_HEADING_PATTERNS without importing production internals. */
+const STRUCTURAL_HEADINGS = [
+    "Validation",
+    "Verification",
+    "Feedback Loop",
+    "Mandatory",
+    "Before Commit",
+    "Validation Suite",
+    "Commands",
+] as const;
+
+interface LintDiagnosticJson {
+    readonly filePath: string;
+    readonly line: number;
+    readonly column?: number;
+    readonly severity: string;
+    readonly message: string;
+    readonly ruleId?: string;
+    readonly target: string;
+}
+
+function compliantBody(title = "Instructions"): string {
+    return [
+        `# ${title}`,
+        "",
+        ...STRUCTURAL_HEADINGS.flatMap((heading) => [
+            `## ${heading}`,
+            "",
+            "Guidance.",
+            "",
+        ]),
+    ].join("\n");
+}
+
+function headingsBody(headings: readonly string[], title = "Partial"): string {
+    return [
+        `# ${title}`,
+        "",
+        ...headings.flatMap((heading) => [
+            `## ${heading}`,
+            "",
+            "Guidance.",
+            "",
+        ]),
+    ].join("\n");
+}
+
+async function runCli(
+    repoDir: string,
+    cliArgs: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const tsxPath = join(process.cwd(), "node_modules", ".bin", "tsx");
+    const entryPath = join(cliPackageDir, "src", "index.ts");
+    try {
+        const result = await execFileAsync(
+            tsxPath,
+            [entryPath, "lint", ...cliArgs],
+            {
+                cwd: repoDir,
+                // biome-ignore lint/style/useNamingConvention: env var
+                env: { ...process.env, NO_COLOR: "1" },
+            },
+        );
+        return {
+            stdout: result.stdout,
+            stderr: result.stderr,
+            exitCode: 0,
+        };
+    } catch (err: unknown) {
+        const execErr = err as {
+            stdout?: string;
+            stderr?: string;
+            code?: number;
+        };
+        return {
+            stdout: execErr.stdout ?? "",
+            stderr: execErr.stderr ?? "",
+            exitCode: execErr.code ?? 1,
+        };
+    }
+}
+
+async function lintInstructionsJson(
+    repoDir: string,
+): Promise<LintDiagnosticJson[]> {
+    const { stdout } = await runCli(repoDir, [
+        "--instructions",
+        "--format",
+        "json",
+    ]);
+    const trimmed = stdout.trim();
+    if (trimmed === "" || trimmed === "[]") {
+        return [];
+    }
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) {
+        throw new Error(`Expected JSON array of diagnostics, got: ${trimmed}`);
+    }
+    return parsed as LintDiagnosticJson[];
+}
+
+/** Normalize macOS /var vs /private/var so diagnostic paths compare stably. */
+function normalizePath(pathValue: string): string {
+    return resolve(pathValue).replace(/^\/private\/var\//, "/var/");
+}
+
+function pathsEqual(left: string, right: string): boolean {
+    return normalizePath(left) === normalizePath(right);
+}
+
+function missingStructural(
+    diagnostics: readonly LintDiagnosticJson[],
+    filePath: string,
+): LintDiagnosticJson[] {
+    return diagnostics.filter(
+        (d) =>
+            d.ruleId === "instruction/missing-structural-heading" &&
+            pathsEqual(d.filePath, filePath),
+    );
+}
+
+function byRule(
+    diagnostics: readonly LintDiagnosticJson[],
+    ruleId: string,
+): LintDiagnosticJson[] {
+    return diagnostics.filter((d) => d.ruleId === ruleId);
+}
+
+function diagnosticOrderKey(d: LintDiagnosticJson): string {
+    return [
+        d.ruleId ?? "",
+        normalizePath(d.filePath),
+        String(d.line),
+        String(d.column ?? 0),
+        d.message,
+    ].join("\0");
+}
+
+describe("Claude instruction import black-box acceptance (CLI)", () => {
+    let projectDir: string;
+
+    async function makeRepoDir(label: string): Promise<string> {
+        const dir = join(projectDir, `${label}-${chance.hash({ length: 6 })}`);
+        await mkdir(dir, { recursive: true });
+        return realpath(dir);
+    }
+
+    beforeAll(async () => {
+        const dir = join(
+            tmpdir(),
+            `claude-import-bb-${chance.hash({ length: 8 })}`,
+        );
+        await mkdir(dir, { recursive: true });
+        projectDir = await realpath(dir);
+    });
+
+    afterAll(async () => {
+        if (projectDir) {
+            await rm(projectDir, { recursive: true, force: true });
+        }
+    });
+
+    describe("A2: wrapper text before/after import with ordered splice", () => {
+        it("should suppress missing-structural-heading on CLAUDE when AGENTS supplies headings via mid-document import", async () => {
+            // Arrange — headings split across pre-import wrapper, imported body, and post-import wrapper
+            // so only ordered splice (not replace-with-import, drop-before, or physical-file-only) yields a full set.
+            const repoDir = await makeRepoDir("a2");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const agentsPath = join(repoDir, "AGENTS.md");
+
+            const preImportHeadings = ["Validation"] as const;
+            const importedHeadings = [
+                "Verification",
+                "Feedback Loop",
+                "Mandatory",
+            ] as const;
+            const postImportHeadings = [
+                "Before Commit",
+                "Validation Suite",
+                "Commands",
+            ] as const;
+
+            await writeFile(
+                claudePath,
+                [
+                    "# Claude wrapper",
+                    "",
+                    "Prose before the import token.",
+                    "",
+                    ...preImportHeadings.flatMap((heading) => [
+                        `## ${heading}`,
+                        "",
+                        "Pre-import guidance.",
+                        "",
+                    ]),
+                    "@./AGENTS.md",
+                    "",
+                    "Prose after the import token.",
+                    "",
+                    ...postImportHeadings.flatMap((heading) => [
+                        `## ${heading}`,
+                        "",
+                        "Local guidance.",
+                        "",
+                    ]),
+                ].join("\n"),
+            );
+            await writeFile(
+                agentsPath,
+                headingsBody(importedHeadings, "Agents"),
+            );
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert — CLAUDE effective doc has all headings via ordered splice
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+            // AGENTS is its own entrypoint and only has the imported third
+            expect(missingStructural(diagnostics, agentsPath).length).toBe(
+                STRUCTURAL_HEADINGS.length - importedHeadings.length,
+            );
+            expect(
+                byRule(diagnostics, "instruction/import-unresolved"),
+            ).toEqual([]);
+        });
+    });
+
+    describe("A3: multiple valid imports; structure split across files", () => {
+        it("should compose structural headings from two imported parts under CLAUDE", async () => {
+            // Arrange
+            const repoDir = await makeRepoDir("a3");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const partA = join(repoDir, "part-a.md");
+            const partB = join(repoDir, "part-b.md");
+
+            const headingsForPartA = [
+                "Validation",
+                "Verification",
+                "Feedback Loop",
+            ] as const;
+            const headingsForPartB = [
+                "Mandatory",
+                "Before Commit",
+                "Validation Suite",
+                "Commands",
+            ] as const;
+
+            await writeFile(
+                claudePath,
+                ["# Claude", "", "@./part-a.md", "", "@./part-b.md", ""].join(
+                    "\n",
+                ),
+            );
+            await writeFile(partA, headingsBody(headingsForPartA, "Part A"));
+            await writeFile(partB, headingsBody(headingsForPartB, "Part B"));
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+            expect(
+                byRule(diagnostics, "instruction/import-unresolved"),
+            ).toEqual([]);
+        });
+    });
+
+    describe("A4: same source imported twice with deterministic positional semantics", () => {
+        it("should expand a repeated import without cycle diagnostics and keep CLAUDE structurally complete", async () => {
+            // Arrange — small dual expand still supplies structure twice without cycle noise
+            const repoDir = await makeRepoDir("a4-structure");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const sharedPath = join(repoDir, "shared.md");
+
+            await writeFile(
+                claudePath,
+                [
+                    "# Claude",
+                    "",
+                    "first",
+                    "@./shared.md",
+                    "middle",
+                    "@./shared.md",
+                    "last",
+                    "",
+                ].join("\n"),
+            );
+            await writeFile(sharedPath, compliantBody("Shared"));
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+            expect(byRule(diagnostics, "instruction/import-cycle")).toEqual([]);
+            expect(
+                byRule(diagnostics, "instruction/import-unresolved"),
+            ).toEqual([]);
+        });
+
+        it("should double-count emitted bytes when the same large source is imported twice", async () => {
+            // Arrange — DEFAULT_MAX_EMITTED_BYTES is 512_000. A body larger than the budget
+            // exhausts emit capacity on the first splice; the second splice then fails with
+            // import-size-exceeded only when both positions are expanded (not dedupe-once).
+            const repoDir = await makeRepoDir("a4-bytes");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const sharedPath = join(repoDir, "shared.md");
+            const largeBody = `${"x".repeat(512_001)}\n`;
+
+            await writeFile(
+                claudePath,
+                [
+                    "# Claude",
+                    "",
+                    ...STRUCTURAL_HEADINGS.flatMap((heading) => [
+                        `## ${heading}`,
+                        "",
+                        "Local.",
+                        "",
+                    ]),
+                    "first",
+                    "@./shared.md",
+                    "middle",
+                    "@./shared.md",
+                    "last",
+                    "",
+                ].join("\n"),
+            );
+            await writeFile(sharedPath, largeBody);
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            expect(byRule(diagnostics, "instruction/import-cycle")).toEqual([]);
+            const sizeExceeded = byRule(
+                diagnostics,
+                "instruction/import-size-exceeded",
+            );
+            expect(sizeExceeded.length).toBeGreaterThanOrEqual(1);
+            expect(
+                pathsEqual(sizeExceeded[0]?.filePath ?? "", claudePath),
+            ).toBe(true);
+        });
+    });
+
+    describe("A5: nested import depth limit (default 4 hops)", () => {
+        it("should include four-hop nested content and suppress missing-structural-heading", async () => {
+            // Arrange — CLAUDE(0) -> h1(1) -> h2(2) -> h3(3) -> h4(4 leaf with headings)
+            const repoDir = await makeRepoDir("a5-ok");
+            const claudePath = join(repoDir, "CLAUDE.md");
+
+            await writeFile(claudePath, "@./h1.md\n");
+            await writeFile(join(repoDir, "h1.md"), "@./h2.md\n");
+            await writeFile(join(repoDir, "h2.md"), "@./h3.md\n");
+            await writeFile(join(repoDir, "h3.md"), "@./h4.md\n");
+            await writeFile(join(repoDir, "h4.md"), compliantBody("Hop4"));
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            expect(
+                byRule(diagnostics, "instruction/import-depth-exceeded"),
+            ).toEqual([]);
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+        });
+
+        it("should emit import-depth-exceeded on the fifth hop and not follow it for structure", async () => {
+            // Arrange — headings only on hop 5 so following it would incorrectly clear missing-structural
+            const repoDir = await makeRepoDir("a5-deep");
+            const claudePath = join(repoDir, "CLAUDE.md");
+
+            await writeFile(claudePath, "@./d1.md\n");
+            await writeFile(join(repoDir, "d1.md"), "@./d2.md\n");
+            await writeFile(join(repoDir, "d2.md"), "@./d3.md\n");
+            await writeFile(join(repoDir, "d3.md"), "@./d4.md\n");
+            await writeFile(join(repoDir, "d4.md"), "leaf-ok\n@./d5.md\n");
+            await writeFile(join(repoDir, "d5.md"), compliantBody("TooDeep"));
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            const depth = byRule(
+                diagnostics,
+                "instruction/import-depth-exceeded",
+            );
+            expect(depth.length).toBeGreaterThanOrEqual(1);
+            expect(
+                pathsEqual(depth[0]?.filePath ?? "", join(repoDir, "d4.md")),
+            ).toBe(true);
+            expect(missingStructural(diagnostics, claudePath).length).toBe(
+                STRUCTURAL_HEADINGS.length,
+            );
+        });
+    });
+
+    describe("A6: direct and indirect cycles with independent branch continuation", () => {
+        it("should emit import-cycle for a direct cycle without hanging", async () => {
+            // Arrange
+            const repoDir = await makeRepoDir("a6-direct");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const otherPath = join(repoDir, "other.md");
+
+            await writeFile(claudePath, "A\n@./other.md\n");
+            await writeFile(otherPath, "B\n@./CLAUDE.md\n");
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            const cycles = byRule(diagnostics, "instruction/import-cycle");
+            expect(cycles.length).toBeGreaterThanOrEqual(1);
+            expect(cycles.some((d) => pathsEqual(d.filePath, otherPath))).toBe(
+                true,
+            );
+        });
+
+        it("should emit import-cycle for an indirect cycle and still expand an independent good branch", async () => {
+            // Arrange
+            const repoDir = await makeRepoDir("a6-indirect");
+            const claudePath = join(repoDir, "CLAUDE.md");
+
+            await writeFile(
+                claudePath,
+                ["@./cycle-a.md", "", "@./good.md", ""].join("\n"),
+            );
+            await writeFile(join(repoDir, "cycle-a.md"), "@./cycle-b.md\n");
+            await writeFile(join(repoDir, "cycle-b.md"), "@./cycle-c.md\n");
+            await writeFile(join(repoDir, "cycle-c.md"), "@./cycle-a.md\n");
+            await writeFile(join(repoDir, "good.md"), compliantBody("Good"));
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert — cycle reported, good branch still supplies structure
+            expect(
+                byRule(diagnostics, "instruction/import-cycle").length,
+            ).toBeGreaterThanOrEqual(1);
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+        });
+    });
+
+    describe("A11: non-import @path forms are not expanded", () => {
+        it("should not emit import-unresolved for fenced, inline, link, or malformed @paths when targets are missing", async () => {
+            // Arrange — only real line-start imports are expandable; fake paths must not produce unresolved
+            const repoDir = await makeRepoDir("a11");
+            const claudePath = join(repoDir, "CLAUDE.md");
+
+            await writeFile(
+                claudePath,
+                [
+                    "# Claude",
+                    "",
+                    "```",
+                    "@./missing-fenced.md",
+                    "```",
+                    "",
+                    "Use `@./missing-inline.md` in docs.",
+                    "",
+                    "See [agents](./missing-link.md) for details.",
+                    "",
+                    "@@./missing-escaped.md",
+                    "",
+                    "@ missing-space.md",
+                    "",
+                    "@./real.md",
+                    "",
+                ].join("\n"),
+            );
+            await writeFile(join(repoDir, "real.md"), compliantBody("Real"));
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            const unresolved = byRule(
+                diagnostics,
+                "instruction/import-unresolved",
+            );
+            expect(unresolved).toEqual([]);
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+            expect(
+                diagnostics.some((d) =>
+                    d.message.includes("missing-fenced.md"),
+                ),
+            ).toBe(false);
+            expect(
+                diagnostics.some((d) =>
+                    d.message.includes("missing-inline.md"),
+                ),
+            ).toBe(false);
+            expect(
+                diagnostics.some((d) => d.message.includes("missing-link.md")),
+            ).toBe(false);
+        });
+    });
+
+    describe("A12: wide unique-file fan-out and repeated-edge limits", () => {
+        it("should emit import-size-exceeded when unique imports exceed DEFAULT_MAX_UNIQUE_FILES (64)", async () => {
+            // Arrange — root counts as unique file #1; 64 distinct targets => 65th unique is rejected
+            const repoDir = await makeRepoDir("a12-unique");
+            const claudePath = join(repoDir, "CLAUDE.md");
+
+            const uniqueCount = 64;
+            const importLines: string[] = [];
+            for (let i = 1; i <= uniqueCount; i += 1) {
+                const name = `u${String(i).padStart(2, "0")}.md`;
+                importLines.push(`@./${name}`);
+                await writeFile(join(repoDir, name), `body-${i}\n`);
+            }
+
+            await writeFile(
+                claudePath,
+                [
+                    "# Claude",
+                    "",
+                    ...STRUCTURAL_HEADINGS.flatMap((heading) => [
+                        `## ${heading}`,
+                        "",
+                        "Local.",
+                        "",
+                    ]),
+                    ...importLines,
+                    "",
+                ].join("\n"),
+            );
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            const sizeExceeded = byRule(
+                diagnostics,
+                "instruction/import-size-exceeded",
+            );
+            expect(sizeExceeded.length).toBeGreaterThanOrEqual(1);
+            expect(
+                pathsEqual(sizeExceeded[0]?.filePath ?? "", claudePath),
+            ).toBe(true);
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+        });
+
+        it("should emit import-size-exceeded when the same target is imported past DEFAULT_MAX_EDGES (256)", async () => {
+            // Arrange — DEFAULT_MAX_EDGES=256; the 257th edge must fail even if the target is unique-cached
+            const repoDir = await makeRepoDir("a12-edges");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const sharedPath = join(repoDir, "shared.md");
+            const edgeCount = 257;
+            const importLines = Array.from(
+                { length: edgeCount },
+                () => "@./shared.md",
+            );
+
+            await writeFile(sharedPath, "shared-body\n");
+            await writeFile(
+                claudePath,
+                [
+                    "# Claude",
+                    "",
+                    ...STRUCTURAL_HEADINGS.flatMap((heading) => [
+                        `## ${heading}`,
+                        "",
+                        "Local.",
+                        "",
+                    ]),
+                    ...importLines,
+                    "",
+                ].join("\n"),
+            );
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            const sizeExceeded = byRule(
+                diagnostics,
+                "instruction/import-size-exceeded",
+            );
+            expect(sizeExceeded.length).toBeGreaterThanOrEqual(1);
+            expect(
+                pathsEqual(sizeExceeded[0]?.filePath ?? "", claudePath),
+            ).toBe(true);
+            expect(byRule(diagnostics, "instruction/import-cycle")).toEqual([]);
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+        });
+    });
+
+    describe("A13: two entrypoints with different context (no bleed)", () => {
+        it("should not let CLAUDE expanded imports suppress missing-structural-heading on AGENTS.md", async () => {
+            // Arrange — CLAUDE imports a private full leaf; AGENTS is thin and must stay incomplete
+            const repoDir = await makeRepoDir("a13");
+            const claudePath = join(repoDir, "CLAUDE.md");
+            const agentsPath = join(repoDir, "AGENTS.md");
+            const leafPath = join(repoDir, "claude-only-leaf.md");
+
+            await writeFile(claudePath, "@./claude-only-leaf.md\n");
+            await writeFile(leafPath, compliantBody("Claude leaf"));
+            await writeFile(
+                agentsPath,
+                [
+                    "# Agents",
+                    "",
+                    "## Commands",
+                    "",
+                    "Only commands on the AGENTS entrypoint.",
+                    "",
+                ].join("\n"),
+            );
+
+            // Act
+            const diagnostics = await lintInstructionsJson(repoDir);
+
+            // Assert
+            expect(missingStructural(diagnostics, claudePath)).toEqual([]);
+            const agentsMissing = missingStructural(diagnostics, agentsPath);
+            expect(agentsMissing.length).toBe(STRUCTURAL_HEADINGS.length - 1);
+            expect(
+                agentsMissing.some((d) => d.message.includes("'Commands'")),
+            ).toBe(false);
+        });
+    });
+
+    describe("deterministic diagnostic ordering", () => {
+        it("should emit the same ordered key diagnostics across repeated CLI runs", async () => {
+            // Arrange — multiple import failures with stable physical provenance
+            const repoDir = await makeRepoDir("order");
+
+            await writeFile(
+                join(repoDir, "CLAUDE.md"),
+                [
+                    "# Claude",
+                    "",
+                    "@./missing-a.md",
+                    "",
+                    "@./mid.md",
+                    "",
+                    "@../escape.md",
+                    "",
+                ].join("\n"),
+            );
+            await writeFile(
+                join(repoDir, "mid.md"),
+                "mid\n@./missing-b.md\n@./missing-c.md\n",
+            );
+
+            // Act
+            const run1 = await lintInstructionsJson(repoDir);
+            const run2 = await lintInstructionsJson(repoDir);
+
+            const importRules = new Set([
+                "instruction/import-unresolved",
+                "instruction/import-escape",
+                "instruction/import-cycle",
+                "instruction/import-depth-exceeded",
+                "instruction/import-size-exceeded",
+            ]);
+            const importDiags1 = run1.filter(
+                (d) => d.ruleId !== undefined && importRules.has(d.ruleId),
+            );
+            const importDiags2 = run2.filter(
+                (d) => d.ruleId !== undefined && importRules.has(d.ruleId),
+            );
+            const keys1 = importDiags1.map(diagnosticOrderKey);
+            const keys2 = importDiags2.map(diagnosticOrderKey);
+
+            // Canonical order mirrors AnalyzeInstructionQualityUseCase.compareImportDiagnostics:
+            // filePath → line → column → ruleId
+            const canonicalKeys = [...importDiags1]
+                .sort((a, b) => {
+                    const pathCmp = normalizePath(a.filePath).localeCompare(
+                        normalizePath(b.filePath),
+                    );
+                    if (pathCmp !== 0) {
+                        return pathCmp;
+                    }
+                    if (a.line !== b.line) {
+                        return a.line - b.line;
+                    }
+                    const aCol = a.column ?? 0;
+                    const bCol = b.column ?? 0;
+                    if (aCol !== bCol) {
+                        return aCol - bCol;
+                    }
+                    return (a.ruleId ?? "").localeCompare(b.ruleId ?? "");
+                })
+                .map(diagnosticOrderKey);
+
+            // Assert
+            expect(keys1.length).toBeGreaterThanOrEqual(3);
+            expect(keys2).toEqual(keys1);
+            expect(keys1).toEqual(canonicalKeys);
+        });
+    });
+});

--- a/packages/cli/src/commands/lint-claude-import.integration.test.ts
+++ b/packages/cli/src/commands/lint-claude-import.integration.test.ts
@@ -1,9 +1,15 @@
 /**
- * Black-box CLI acceptance locks for Claude `@` instruction import expansion
- * (matrix cells A2–A6, A11–A13 + deterministic diagnostic ordering).
+ * End-customer acceptance locks for shared Claude instruction imports.
  *
- * Runs the real CLI entrypoint via tsx against tmpdir fixtures with real discovery
- * (root CLAUDE.md + AGENTS.md only as entrypoints).
+ * Persona: multi-harness repo authors who keep a thin CLAUDE.md wrapper that
+ * `@`-imports canonical AGENTS.md (and related) content. They run
+ * `lousy-agents lint --instructions` (CLI / CI / reviewdog) and expect:
+ * - no false missing-heading noise on correct wrappers
+ * - actionable diagnostics when imports are broken or unsafe
+ * - isolation between harness entrypoints (Claude vs AGENTS)
+ *
+ * Boundary: real CLI entrypoint via tsx against tmpdir fixtures with real
+ * discovery (root CLAUDE.md + AGENTS.md as entrypoints).
  */
 
 import { execFile } from "node:child_process";
@@ -24,7 +30,7 @@ const cliPackageDir = resolve(
     "..",
 );
 
-/** Mirrors DEFAULT_STRUCTURAL_HEADING_PATTERNS without importing production internals. */
+/** Recommended structural sections customers expect in instruction docs. */
 const STRUCTURAL_HEADINGS = [
     "Validation",
     "Verification",
@@ -162,7 +168,7 @@ function diagnosticOrderKey(d: LintDiagnosticJson): string {
     ].join("\0");
 }
 
-describe("Claude instruction import black-box acceptance (CLI)", () => {
+describe("when customers lint shared Claude instruction imports", () => {
     let projectDir: string;
 
     async function makeRepoDir(label: string): Promise<string> {
@@ -186,11 +192,11 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         }
     });
 
-    describe("A2: wrapper text before/after import with ordered splice", () => {
-        it("should suppress missing-structural-heading on CLAUDE when AGENTS supplies headings via mid-document import", async () => {
-            // Arrange — headings split across pre-import wrapper, imported body, and post-import wrapper
-            // so only ordered splice (not replace-with-import, drop-before, or physical-file-only) yields a full set.
-            const repoDir = await makeRepoDir("a2");
+    describe("when a thin CLAUDE.md wrapper mixes local guidance with an imported shared doc", () => {
+        it("should not report missing structural headings on the wrapper when the combined document is complete", async () => {
+            // Arrange — customer keeps Validation on the wrapper, middle sections in AGENTS.md,
+            // and remaining sections after the import (Coach-style shared-instruction layout).
+            const repoDir = await makeRepoDir("wrapper-local-and-import");
             const claudePath = join(repoDir, "CLAUDE.md");
             const agentsPath = join(repoDir, "AGENTS.md");
 
@@ -239,9 +245,9 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert — CLAUDE effective doc has all headings via ordered splice
+            // Assert — wrapper is complete via effective shared content
             expect(missingStructural(diagnostics, claudePath)).toEqual([]);
-            // AGENTS is its own entrypoint and only has the imported third
+            // AGENTS is still judged on its own thin body as a separate entrypoint
             expect(missingStructural(diagnostics, agentsPath).length).toBe(
                 STRUCTURAL_HEADINGS.length - importedHeadings.length,
             );
@@ -251,10 +257,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A3: multiple valid imports; structure split across files", () => {
-        it("should compose structural headings from two imported parts under CLAUDE", async () => {
+    describe("when instruction structure is split across several imported files", () => {
+        it("should treat the CLAUDE.md entrypoint as complete when the imported parts supply every required section", async () => {
             // Arrange
-            const repoDir = await makeRepoDir("a3");
+            const repoDir = await makeRepoDir("split-across-imports");
             const claudePath = join(repoDir, "CLAUDE.md");
             const partA = join(repoDir, "part-a.md");
             const partB = join(repoDir, "part-b.md");
@@ -291,10 +297,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A4: same source imported twice with deterministic positional semantics", () => {
-        it("should expand a repeated import without cycle diagnostics and keep CLAUDE structurally complete", async () => {
-            // Arrange — small dual expand still supplies structure twice without cycle noise
-            const repoDir = await makeRepoDir("a4-structure");
+    describe("when the same shared file is imported more than once in one wrapper", () => {
+        it("should accept the wrapper as complete without reporting a circular import", async () => {
+            // Arrange — customers sometimes re-include a shared fragment at two positions
+            const repoDir = await makeRepoDir("repeated-import-complete");
             const claudePath = join(repoDir, "CLAUDE.md");
             const sharedPath = join(repoDir, "shared.md");
 
@@ -324,11 +330,9 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             ).toEqual([]);
         });
 
-        it("should double-count emitted bytes when the same large source is imported twice", async () => {
-            // Arrange — DEFAULT_MAX_EMITTED_BYTES is 512_000. A body larger than the budget
-            // exhausts emit capacity on the first splice; the second splice then fails with
-            // import-size-exceeded only when both positions are expanded (not dedupe-once).
-            const repoDir = await makeRepoDir("a4-bytes");
+        it("should warn when repeating a very large import would make effective instructions unbounded", async () => {
+            // Arrange — a huge shared body included twice must not silently grow without bound
+            const repoDir = await makeRepoDir("repeated-import-too-large");
             const claudePath = join(repoDir, "CLAUDE.md");
             const sharedPath = join(repoDir, "shared.md");
             const largeBody = `${"x".repeat(512_001)}\n`;
@@ -357,7 +361,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert
+            // Assert — actionable size warning on the wrapper, not a cycle false positive
             expect(byRule(diagnostics, "instruction/import-cycle")).toEqual([]);
             const sizeExceeded = byRule(
                 diagnostics,
@@ -370,10 +374,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A5: nested import depth limit (default 4 hops)", () => {
-        it("should include four-hop nested content and suppress missing-structural-heading", async () => {
-            // Arrange — CLAUDE(0) -> h1(1) -> h2(2) -> h3(3) -> h4(4 leaf with headings)
-            const repoDir = await makeRepoDir("a5-ok");
+    describe("when shared docs nest imports several levels deep", () => {
+        it("should honor a moderate nest of shared files and not warn about missing headings on the wrapper", async () => {
+            // Arrange — CLAUDE → layer → layer → layer → leaf with full guidance
+            const repoDir = await makeRepoDir("moderate-nest");
             const claudePath = join(repoDir, "CLAUDE.md");
 
             await writeFile(claudePath, "@./h1.md\n");
@@ -392,9 +396,9 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             expect(missingStructural(diagnostics, claudePath)).toEqual([]);
         });
 
-        it("should emit import-depth-exceeded on the fifth hop and not follow it for structure", async () => {
-            // Arrange — headings only on hop 5 so following it would incorrectly clear missing-structural
-            const repoDir = await makeRepoDir("a5-deep");
+        it("should warn at the too-deep import and not pretend deeper content completed the wrapper", async () => {
+            // Arrange — required sections live only past the supported nest depth
+            const repoDir = await makeRepoDir("too-deep-nest");
             const claudePath = join(repoDir, "CLAUDE.md");
 
             await writeFile(claudePath, "@./d1.md\n");
@@ -407,7 +411,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert
+            // Assert — depth warning on the file that tried to go too deep; wrapper still incomplete
             const depth = byRule(
                 diagnostics,
                 "instruction/import-depth-exceeded",
@@ -422,10 +426,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A6: direct and indirect cycles with independent branch continuation", () => {
-        it("should emit import-cycle for a direct cycle without hanging", async () => {
+    describe("when import graphs contain cycles", () => {
+        it("should report a circular import quickly when two files point at each other", async () => {
             // Arrange
-            const repoDir = await makeRepoDir("a6-direct");
+            const repoDir = await makeRepoDir("direct-cycle");
             const claudePath = join(repoDir, "CLAUDE.md");
             const otherPath = join(repoDir, "other.md");
 
@@ -443,9 +447,9 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             );
         });
 
-        it("should emit import-cycle for an indirect cycle and still expand an independent good branch", async () => {
-            // Arrange
-            const repoDir = await makeRepoDir("a6-indirect");
+        it("should still use a healthy import branch when another branch is circular", async () => {
+            // Arrange — one broken cycle plus a complete shared doc on a separate import
+            const repoDir = await makeRepoDir("cycle-plus-good-branch");
             const claudePath = join(repoDir, "CLAUDE.md");
 
             await writeFile(
@@ -460,7 +464,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert — cycle reported, good branch still supplies structure
+            // Assert — cycle is visible, but the good branch still completes the wrapper
             expect(
                 byRule(diagnostics, "instruction/import-cycle").length,
             ).toBeGreaterThanOrEqual(1);
@@ -468,10 +472,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A11: non-import @path forms are not expanded", () => {
-        it("should not emit import-unresolved for fenced, inline, link, or malformed @paths when targets are missing", async () => {
-            // Arrange — only real line-start imports are expandable; fake paths must not produce unresolved
-            const repoDir = await makeRepoDir("a11");
+    describe("when docs mention @paths that are not real imports", () => {
+        it("should not warn about missing files for examples inside code, links, or malformed tokens", async () => {
+            // Arrange — only a real line-start import should be followed
+            const repoDir = await makeRepoDir("docs-not-imports");
             const claudePath = join(repoDir, "CLAUDE.md");
 
             await writeFile(
@@ -500,7 +504,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert
+            // Assert — no false "file not found" noise from documentation examples
             const unresolved = byRule(
                 diagnostics,
                 "instruction/import-unresolved",
@@ -523,10 +527,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A12: wide unique-file fan-out and repeated-edge limits", () => {
-        it("should emit import-size-exceeded when unique imports exceed DEFAULT_MAX_UNIQUE_FILES (64)", async () => {
-            // Arrange — root counts as unique file #1; 64 distinct targets => 65th unique is rejected
-            const repoDir = await makeRepoDir("a12-unique");
+    describe("when an import graph is pathologically wide", () => {
+        it("should warn when a wrapper pulls in more unique files than lint will expand", async () => {
+            // Arrange — many distinct shared fragments under one wrapper
+            const repoDir = await makeRepoDir("too-many-unique-imports");
             const claudePath = join(repoDir, "CLAUDE.md");
 
             const uniqueCount = 64;
@@ -556,7 +560,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert
+            // Assert — bounded work with a clear warning on the wrapper
             const sizeExceeded = byRule(
                 diagnostics,
                 "instruction/import-size-exceeded",
@@ -568,9 +572,9 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             expect(missingStructural(diagnostics, claudePath)).toEqual([]);
         });
 
-        it("should emit import-size-exceeded when the same target is imported past DEFAULT_MAX_EDGES (256)", async () => {
-            // Arrange — DEFAULT_MAX_EDGES=256; the 257th edge must fail even if the target is unique-cached
-            const repoDir = await makeRepoDir("a12-edges");
+        it("should warn when the same import is repeated far beyond a reasonable graph size", async () => {
+            // Arrange — pathological repeat of one fragment must not hang or run unbounded
+            const repoDir = await makeRepoDir("too-many-repeated-imports");
             const claudePath = join(repoDir, "CLAUDE.md");
             const sharedPath = join(repoDir, "shared.md");
             const edgeCount = 257;
@@ -613,10 +617,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("A13: two entrypoints with different context (no bleed)", () => {
-        it("should not let CLAUDE expanded imports suppress missing-structural-heading on AGENTS.md", async () => {
-            // Arrange — CLAUDE imports a private full leaf; AGENTS is thin and must stay incomplete
-            const repoDir = await makeRepoDir("a13");
+    describe("when CLAUDE.md and AGENTS.md are both present as entrypoints", () => {
+        it("should not let Claude's imported guidance silence missing-section warnings on AGENTS.md", async () => {
+            // Arrange — Claude imports a private complete leaf; AGENTS is intentionally thin
+            const repoDir = await makeRepoDir("entrypoint-isolation");
             const claudePath = join(repoDir, "CLAUDE.md");
             const agentsPath = join(repoDir, "AGENTS.md");
             const leafPath = join(repoDir, "claude-only-leaf.md");
@@ -638,7 +642,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             // Act
             const diagnostics = await lintInstructionsJson(repoDir);
 
-            // Assert
+            // Assert — each harness entrypoint is judged on its own effective content
             expect(missingStructural(diagnostics, claudePath)).toEqual([]);
             const agentsMissing = missingStructural(diagnostics, agentsPath);
             expect(agentsMissing.length).toBe(STRUCTURAL_HEADINGS.length - 1);
@@ -648,10 +652,10 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
         });
     });
 
-    describe("deterministic diagnostic ordering", () => {
-        it("should emit the same ordered key diagnostics across repeated CLI runs", async () => {
-            // Arrange — multiple import failures with stable physical provenance
-            const repoDir = await makeRepoDir("order");
+    describe("when CI consumers re-run lint on the same broken import graph", () => {
+        it("should report the same import problems in the same order every time", async () => {
+            // Arrange — missing targets and a path escape that reviewdog/JSON consumers will annotate
+            const repoDir = await makeRepoDir("stable-diagnostics");
 
             await writeFile(
                 join(repoDir, "CLAUDE.md"),
@@ -691,8 +695,7 @@ describe("Claude instruction import black-box acceptance (CLI)", () => {
             const keys1 = importDiags1.map(diagnosticOrderKey);
             const keys2 = importDiags2.map(diagnosticOrderKey);
 
-            // Canonical order mirrors AnalyzeInstructionQualityUseCase.compareImportDiagnostics:
-            // filePath → line → column → ruleId
+            // Stable consumer order: file path → line → column → rule
             const canonicalKeys = [...importDiags1]
                 .sort((a, b) => {
                     const pathCmp = normalizePath(a.filePath).localeCompare(


### PR DESCRIPTION
## Summary

Implements [#1105](https://github.com/zpratt/lousy-agents/issues/1105) (Story 4 of epic [#1042](https://github.com/zpratt/lousy-agents/issues/1042)): CLI black-box acceptance locks for Claude `@` import ordered-splice, multi-hop, cycles, non-token `@`, resource bounds, isolation, and deterministic diagnostic ordering.

**Depends on:** #1104 / #1114 (merged into `beta`).

Also adds a small workflow so `Closes`/`Fixes` keywords close issues when PRs merge into **beta** (GitHub only auto-closes on the default branch).

## Single concern

Lock remaining black-box matrix cells at the real CLI boundary (`lint --instructions --format json`). No expander behavior changes required; production already satisfied the matrix under unit coverage.

## Acceptance criteria → evidence

| Criterion | Evidence |
| --- | --- |
| **A2** wrapper before/after; ordered splice | `lint-claude-import.integration.test.ts` A2 — headings split pre-import / import / post-import |
| **A3** multiple valid imports; structure split | A3 — part-a + part-b under CLAUDE |
| **A4** same source twice; byte accounting | A4 structure + double-count via body > 512_000 → `import-size-exceeded` |
| **A5** four hops ok; five hops depth | A5-ok + A5-deep (`import-depth-exceeded` on d4) |
| **A6** direct + indirect cycles; independent branch | A6-direct + A6-indirect (good branch supplies structure) |
| **A11** non-token `@` not expanded | A11 fenced/inline/link/malformed |
| **A12** wide graph / repeated expansion limits | unique-files 64 + repeated edges 257 |
| **A13** two entrypoints no bleed | CLAUDE expanded leaf vs AGENTS own entrypoint |
| Deterministic diagnostic ordering | run-stable + canonical filePath/line/column/ruleId sort |
| Beta merge closes linked issue | `.github/workflows/close-issues-on-beta-merge.yml` |

## Red → green acceptance proof

1. Added CLI black-box suite; 11 cases green against existing expander (acceptance lock).
2. Reviewer FINDINGS on weak A2/A4/A12/ordering → strengthened assertions → **13 passed**.
3. Implementer → reviewer **PASS** (1 rework cycle).

## Validation

```bash
npm run test:integration -- packages/cli/src/commands/lint-claude-import.integration.test.ts  # 13 passed
npx biome check packages/cli/src/commands/lint-claude-import.integration.test.ts
mise run ci   # exit 0
```

## Test plan

- [x] CLI black-box A2–A6, A11–A13 + ordering
- [x] Adversarial graphs complete quickly (~5s suite)
- [x] `mise run ci` green
- [ ] CI green on PR

## Orchestration notes

- Coach `implement-issue` flow: 1 task × implementer/reviewer (1 rework cycle).
- Target branch: **beta** (epic #1042 slice work).

Closes #1105