### PR TITLE
docs(lint): document Claude effective instruction imports (#1106)

### DIFF
--- a/docs/lint.md
+++ b/docs/lint.md
@@ -347,11 +347,87 @@ Each feedback loop command is scored on three dimensions (0 or 1 each):
 | `instruction/command-not-in-code-block` | `warn` | Command appears only in prose, not in a code block |
 | `instruction/command-outside-section` | `warn` | Command is not under a dedicated feedback loop section |
 | `instruction/missing-error-handling` | `warn` | Command has no error handling guidance |
-| `instruction/missing-structural-heading` | `warn` | Instruction file is missing one or more recommended structural heading sections; may emit multiple warnings per file (one per missing section) |
+| `instruction/missing-structural-heading` | `warn` | Instruction file is missing one or more recommended structural heading sections; may emit multiple warnings per file (one per missing section). For Claude entrypoints (`CLAUDE.md`), evaluated against the **effective** document after `@` import expansion |
+| `instruction/import-unresolved` | `warn` | Claude `@` import target could not be resolved, or is not a regular file |
+| `instruction/import-escape` | `warn` | Claude `@` import escapes the repository root, or uses an absolute / `~/` path |
+| `instruction/import-symlink` | `warn` | Claude `@` import path contains a symbolic link (final target or intermediate) |
+| `instruction/import-cycle` | `warn` | Claude `@` import graph contains a cycle |
+| `instruction/import-depth-exceeded` | `warn` | Claude `@` import exceeds the maximum hop depth |
+| `instruction/import-size-exceeded` | `warn` | Claude `@` import expansion exceeded a size or graph limit (unique files, edges, emitted bytes, or per-file bytes) |
 
-The `instruction/missing-structural-heading` rule warns when an instruction file does not contain one or more of the following recommended heading sections: **Validation**, **Verification**, **Feedback Loop**, **Mandatory**, **Before Commit**, **Validation Suite**, **Commands**. These headings guide coding agents through validation and verification workflows. Because instruction files stack on each other across the filesystem, this rule fires per file and is a warning (not an error).
+The `instruction/missing-structural-heading` rule warns when an instruction file does not contain one or more of the following recommended heading sections: **Validation**, **Verification**, **Feedback Loop**, **Mandatory**, **Before Commit**, **Validation Suite**, **Commands**. These headings guide coding agents through validation and verification workflows. Because instruction files stack on each other across the filesystem, this rule fires per file and is a warning (not an error). For Claude entrypoints, headings are checked on the **effective** document after verified `@` imports are expanded (see [Claude shared-instruction imports](#claude-shared-instruction-imports)), so a thin wrapper that imports a shared file with those headings does not get false missing-heading warnings.
 
-The **composite score** per command is the average of the three dimensions. The **overall quality score** (0–100%) is the average of all mandatory command composite scores.
+The **composite score** per command is the average of the three dimensions. The **overall quality score** (0–100%) is the average of all mandatory command composite scores. Suppressing missing-heading warnings via import expansion does **not** by itself change `overallQualityScore` — headings are diagnostic-only and are not a scoring dimension. Expansion can still change the score when imported content affects command-scoring rules (structural context, execution clarity, loop completeness) that consume the effective body.
+
+### Claude shared-instruction imports
+
+When `lint --instructions` analyzes a Claude entrypoint (`CLAUDE.md` format), it expands verified Claude `@` imports into a single **ordered effective document**, then runs content-sensitive instruction rules against that expanded body. Other instruction formats (Copilot, root `AGENTS.md`, custom agents) are analyzed as physical files only — no import expansion.
+
+#### Token recognition
+
+Only **verified native `@path` tokens** are imports:
+
+- Match is line-start `@path` (same shape as doctor `HARD_IMPORT`)
+- The path must include `/` (for example `@./AGENTS.md` or `@../shared/rules.md`)
+- Tokens inside inline code or fenced code blocks are ignored
+- Markdown links (`[text](./file.md)`) are **not** imports
+
+#### Ordered splice
+
+A successful import is **spliced at the token position** in document order: content before the token, then the expanded import body (itself expanded recursively), then content after the token. Expansion is not a set-union of files and not append-at-end.
+
+#### Path policy
+
+Import targets resolve **relative to the importing file**, must stay **inside the repository root**, and must be **regular files**:
+
+- Importer-relative resolution (`@./AGENTS.md` next to the importer)
+- In-repo regular files only
+- **Symlink-hostile**: both intermediate path components and the final target are rejected if they are symbolic links
+- Absolute paths and `~/` (home-directory) paths are rejected (`instruction/import-escape`)
+
+#### Safety limits (internal defaults)
+
+Limits are fixed internal defaults today (not configurable via CLI flags). They match the shipped expander defaults:
+
+| Limit | Default |
+| ----- | ------- |
+| Max depth / hops | `4` (root entrypoint is hop `0`; the first import is hop `1`) |
+| Max unique files | `64` |
+| Max edges | `256` |
+| Max emitted bytes | `512_000` |
+| Max file bytes (per read) | `1_048_576` |
+
+Exceeding a size/graph limit emits `instruction/import-size-exceeded`. Exceeding hop depth emits `instruction/import-depth-exceeded`.
+
+#### Branch-local failures
+
+Import failures are **branch-local**: a failed edge stays unexpanded (the original `@path` token remains in the effective text for that edge), and independent valid edges on the same file or elsewhere in the graph continue to expand. Cycles, missing targets, escapes, symlinks, and limit hits do not abort the whole analysis.
+
+#### Provenance and output
+
+- **Diagnostics** for import failures point at the **owning physical importer file** and the token location (line/column when available), not a synthetic effective path. CLI `--format json` / `rdjsonl` emit those diagnostics only (no quality-result envelope)
+- **MCP** `analyze_instruction_quality` (and the in-memory library `InstructionQualityResult`) include additive `effectiveDocuments` when Claude entrypoints were expanded. Each entry has:
+  - `effectiveRoot` — absolute path of the Claude entrypoint
+  - `resolvedImports` — absolute paths of successfully resolved import targets (first-seen order)
+- **Human CLI** prints a resolved-import count per expanded entrypoint using the absolute effective root, for example: `/repo/CLAUDE.md: 1 resolved import(s)`
+
+#### Non-goals
+
+- No hierarchical merge simulation for Codex, OpenCode, Pi, or other multi-file instruction stacks
+- Copilot `@` references are deferred (not expanded)
+- Markdown links are not imports
+- Only verified native `@path` tokens outside code spans/fences participate
+- Limits are not exposed as user-facing CLI flags
+
+#### Coach-style wrapper pattern
+
+A common pattern is a thin Claude entrypoint that imports shared instructions:
+
+```markdown
+@./AGENTS.md
+```
+
+When `AGENTS.md` already has the recommended structural headings, `instruction/missing-structural-heading` is evaluated on the expanded effective document, so the thin `CLAUDE.md` wrapper does **not** get false missing-heading warnings. Shared body content also participates in command-quality scoring through the same effective document.
 
 ### Examples
 
@@ -361,6 +437,7 @@ The **composite score** per command is the average of the three dimensions. The 
 Discovered 2 instruction file(s)
   .github/copilot-instructions.md (copilot-instructions)
   CLAUDE.md (claude-md)
+  /repo/CLAUDE.md: 1 resolved import(s)
 Overall instruction quality score: 67%
 ⚠ Some commands are not documented in code blocks
 ```

--- a/packages/cli/src/commands/lint-instruction-display.test.ts
+++ b/packages/cli/src/commands/lint-instruction-display.test.ts
@@ -107,4 +107,88 @@ describe("displayInstructionQuality", () => {
             ).toBe(false);
         });
     });
+
+    describe("when instruction diagnostics are present (human feedback)", () => {
+        it("should print each diagnostic with path, line, and message so humans can act without --format json", () => {
+            // Arrange — import failure + missing heading (same path humans hit on coach/lousy-iam)
+            const warnSpy = vi
+                .spyOn(consola, "warn")
+                .mockImplementation(() => {});
+            vi.spyOn(consola, "info").mockImplementation(() => {});
+            vi.spyOn(consola, "error").mockImplementation(() => {});
+
+            const claudePath = "/repo/CLAUDE.md";
+            const importMessage =
+                "Import target could not be resolved: ./missing.md";
+            const headingMessage =
+                "Missing 'Validation' heading section. Agents need this section.";
+            const output: LintOutput = {
+                diagnostics: [
+                    {
+                        filePath: claudePath,
+                        line: 1,
+                        severity: "warning",
+                        message: importMessage,
+                        ruleId: "instruction/import-unresolved",
+                        target: "instruction",
+                    },
+                    {
+                        filePath: claudePath,
+                        line: 1,
+                        severity: "warning",
+                        message: headingMessage,
+                        ruleId: "instruction/missing-structural-heading",
+                        target: "instruction",
+                    },
+                ],
+                target: "instruction",
+                filesAnalyzed: [claudePath],
+                summary: {
+                    totalFiles: 1,
+                    totalErrors: 0,
+                    totalWarnings: 2,
+                    totalInfos: 0,
+                },
+                qualityResult: {
+                    discoveredFiles: [
+                        { filePath: claudePath, format: "claude-md" },
+                    ],
+                    commandScores: [],
+                    overallQualityScore: 0,
+                    suggestions: [],
+                    parsingErrors: [],
+                    effectiveDocuments: [
+                        {
+                            effectiveRoot: claudePath,
+                            resolvedImports: [],
+                        },
+                    ],
+                },
+            };
+
+            // Act
+            displayInstructionQuality(output);
+
+            // Assert — match skills/agents human shape: path:line: message
+            const warnMessages = warnSpy.mock.calls.map((call) =>
+                String(call[0]),
+            );
+            expect(
+                warnMessages.some(
+                    (msg) =>
+                        msg.includes(claudePath) &&
+                        msg.includes(":1:") &&
+                        msg.includes(importMessage),
+                ),
+            ).toBe(true);
+            expect(
+                warnMessages.some(
+                    (msg) =>
+                        msg.includes(claudePath) &&
+                        msg.includes(":1:") &&
+                        msg.includes(headingMessage),
+                ),
+            ).toBe(true);
+        });
+    });
 });

--- a/packages/cli/src/commands/lint-instruction-display.ts
+++ b/packages/cli/src/commands/lint-instruction-display.ts
@@ -5,12 +5,27 @@
 import type { LintOutput } from "@lousy-agents/lint";
 import { consola } from "consola";
 
+const SEVERITY_LOGGERS = {
+    error: (msg: string) => consola.error(msg),
+    warning: (msg: string) => consola.warn(msg),
+    info: (msg: string) => consola.info(msg),
+} as const;
+
 function warnSuggestions(
     suggestions: ReadonlyArray<{ message: string }>,
 ): void {
     for (const suggestion of suggestions) {
         consola.warn(suggestion.message);
     }
+}
+
+function logDiagnostic(d: LintOutput["diagnostics"][number]): void {
+    const fieldInfo = d.field ? ` [${d.field}]` : "";
+    const message = `${d.filePath}:${d.line}${fieldInfo}: ${d.message}`;
+    const log =
+        SEVERITY_LOGGERS[d.severity as keyof typeof SEVERITY_LOGGERS] ??
+        SEVERITY_LOGGERS.info;
+    log(message);
 }
 
 /**
@@ -44,5 +59,8 @@ export function displayInstructionQuality(output: LintOutput): void {
     consola.info(
         `Overall instruction quality score: ${result.overallQualityScore}%`,
     );
+    for (const d of output.diagnostics) {
+        logDiagnostic(d);
+    }
     warnSuggestions(result.suggestions);
 }


### PR DESCRIPTION
## Summary

Documents the shipped Claude `@` effective-instruction import behavior for `lint --instructions`, completing the public definition of done for epic #1042.

- Adds `### Claude shared-instruction imports` covering token recognition, ordered splice, path policy, safety limits, branch-local failures, provenance, non-goals, and the Coach `CLAUDE.md` → `@./AGENTS.md` pattern
- Extends the instruction rule table with `instruction/import-*` diagnostics (default `warn`)
- Clarifies that missing-heading checks for Claude entrypoints run on the **effective** document, and that heading suppression alone does not change `overallQualityScore`

Closes #1106
Related: #1042

## Acceptance criteria → evidence

| Criterion | Evidence |
| --- | --- |
| Expands verified Claude `@` into ordered effective document | `docs/lint.md` — Claude shared-instruction imports + ordered splice |
| Path policy (importer-relative, in-repo regular, symlink-hostile, no abs/`~/`) | Path policy subsection |
| Limits: depth 4, unique 64, edges 256, emitted 512KB, file 1MiB | Safety limits table (matches `instruction-import-expand.ts` defaults) |
| Branch-local failures | Branch-local failures subsection |
| Provenance (physical importer diagnostics; MCP/library `effectiveDocuments`; human absolute root counts) | Provenance and output — explicitly not CLI `--format json` quality envelope |
| Import rule IDs default warn | Rule IDs table |
| Non-goals (no hierarchical merge; Copilot `@` deferred; MD links not imports) | Non-goals list |
| Coach wrapper example | Coach-style wrapper pattern |
| Matches implemented behavior | Cross-checked against expander, analyze-instruction-quality, lint-instruction-display, MCP tool |

## Validation

- `npx markdownlint-cli2 docs/lint.md` — 0 issues
- Docs-only change; no code/test surface

## Implementer / reviewer

- Single implementer → reviewer cycle (docs task)
- Reviewer FINDINGS (2): CLI JSON vs MCP provenance attribution; absolute path in human example — fixed; re-review **PASS**

## Test plan

- [x] markdownlint clean on `docs/lint.md`
- [ ] Spot-check rendered docs against `lint --instructions` on a Coach-style wrapper repo
- [ ] Confirm no contradiction with CLI help / MCP tool descriptions